### PR TITLE
Add typing to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ jinja2
 pytest
 requests
 werkzeug
+typing


### PR DESCRIPTION
Didn't look deeply in it, but when I wanted to check it out, I noticed that typing was used but isn't listed in your requirements file. 

This PR adds typing (also without version pinning).