### PR TITLE
Optimise `ResponseData` and `Response`

### DIFF
--- a/apistar/__init__.py
+++ b/apistar/__init__.py
@@ -11,7 +11,7 @@ from apistar.http import Request, Response, QueryParams, Headers, ResponseData
 from apistar.routing import Route
 
 
-__version__ = '0.1.6'
+__version__ = '0.1.7'
 __all__ = [
     'App', 'Route',
     'WSGIEnviron', 'WSGIResponse', 'Request', 'Response', 'QueryParams', 'Headers'

--- a/apistar/http.py
+++ b/apistar/http.py
@@ -143,12 +143,28 @@ class Response(object):
     __slots__ = ('data', 'content', 'status', 'headers')
 
     def __init__(self, data: Any, status: int=200, headers: HeadersType=None):
-        if isinstance(headers, dict):
-            headers = list(headers.items())
+        content = json.dumps(data).encode('utf-8')
+
+        if headers is None:
+            headers_dict = {}
+            headers_list = []
+        elif isinstance(headers, dict):
+            headers_dict = headers
+            headers_list = list(headers.items())
+        elif isinstance(headers, list):
+            headers_dict = dict(headers)
+            headers_list = headers
+        else:
+            headers_dict = headers
+            headers_list = headers.to_list()
+
+        if 'Content-Length' not in headers_dict:
+            headers_list += [('Content-Length', str(len(content)))]
+
         self.data = data
         self.content = json.dumps(data).encode('utf-8')
         self.status = status
-        self.headers = Headers(headers)
+        self.headers = Headers(headers_list)
 
     @classmethod
     def build(cls, data: ResponseData):

--- a/apistar/routing.py
+++ b/apistar/routing.py
@@ -112,7 +112,7 @@ class Router(object):
                 extra_annotations['return'] = http.ResponseData
 
             # Determine the pipeline for the view.
-            pipeline = pipelines.build_pipeline(view, initial_types, required_type, extra_annotations)
+            pipeline = pipelines.build_pipeline(view, initial_types, None, extra_annotations)
             views[name] = Endpoint(view, pipeline)
 
         # Add pipelines for 404 and 405 cases.


### PR DESCRIPTION
Unroll response and response_data handling into the main WSGI function itself.

This makes the `return {...}` case as fast as `return WSGIResponse()`, but does also mean we put more logic into the main wsgi handling block, rather than keeping it componentized.

I'm going to close this off for now, but it may well be something we choose to come back to.