### PR TITLE
Use max-line-length = 120

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,2 @@
 [flake8]
-ignore=E501
+max-line-length = 127

--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,2 @@
 [flake8]
-max-line-length = 127
+max-line-length = 120

--- a/apistar/commands/base.py
+++ b/apistar/commands/base.py
@@ -16,7 +16,8 @@ PROJECT_TEMPLATE_CHOICES = os.listdir(PROJECT_TEMPLATES_DIR)
 
 @click.command(help='Create a new project in TARGET_DIR.')
 @click.argument('target_dir', default='')
-@click.option('--template', type=click.Choice(PROJECT_TEMPLATE_CHOICES), default='standard', help='Select the project template to use.')
+@click.option('--template', type=click.Choice(PROJECT_TEMPLATE_CHOICES), default='standard',
+              help='Select the project template to use.')
 @click.option('-f', '--force', is_flag=True, help='Overwrite any existing project files.')
 def new(target_dir, template, force):
     source_dir = os.path.join(PROJECT_TEMPLATES_DIR, template)


### PR DESCRIPTION
Instead of ignoring all line-too-long errors, set max-line-length to something more reasonable?  127 characters is the width of the GitHub code viewer.