### PR TITLE
Set content-type and content-length on responses

### DIFF
--- a/apistar/http.py
+++ b/apistar/http.py
@@ -151,12 +151,38 @@ class Response(object):
     __slots__ = ('data', 'content', 'status', 'headers')
 
     def __init__(self, data: Any, status: int=200, headers: HeadersType=None) -> None:
-        if isinstance(headers, dict):
-            headers = list(headers.items())
+        if headers is None:
+            headers_dict = {}  # type: Union[Dict[str, str], Headers]
+            headers_list = []  # type: List[Tuple[str, str]]
+        elif isinstance(headers, dict):
+            headers_dict = headers
+            headers_list = list(headers.items())
+        elif isinstance(headers, list):
+            headers_dict = dict(headers)
+            headers_list = headers
+        else:
+            headers_dict = headers
+            headers_list = headers.to_list()
+
+        if isinstance(data, str):
+            content = data.encode('utf-8')
+            content_type = 'text/html; charset=utf-8'
+        elif isinstance(data, bytes):
+            content = data
+            content_type = 'text/html; charset=utf-8'
+        else:
+            content = json.dumps(data).encode('utf-8')
+            content_type = 'application/json'
+
+        if 'Content-Length' not in headers_dict:
+            headers_list += [('Content-Length', str(len(content)))]
+        if 'Content-Type' not in headers_dict:
+            headers_list += [('Content-Type', content_type)]
+
         self.data = data
-        self.content = json.dumps(data).encode('utf-8')
+        self.content = content
         self.status = status
-        self.headers = Headers(headers)
+        self.headers = Headers(headers_list)
 
     @classmethod
     def build(cls, data: ResponseData):

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -209,14 +209,6 @@ def test_request():
     }
 
 
-def get_request(request: http.Request) -> http.Response:
-    return http.Response({
-        'method': request.method,
-        'url': request.url,
-        'headers': dict(request.headers)
-    })
-
-
 # Test reponse types
 
 def binary_response():

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -207,3 +207,49 @@ def test_request():
             'User-Agent': 'requests_client'
         }
     }
+
+
+def get_request(request: http.Request) -> http.Response:
+    return http.Response({
+        'method': request.method,
+        'url': request.url,
+        'headers': dict(request.headers)
+    })
+
+
+# Test reponse types
+
+def binary_response():
+    return b'<html><h1>Hello, world</h1></html>'
+
+
+def text_response():
+    return '<html><h1>Hello, world</h1></html>'
+
+
+def data_response():
+    return {'hello': 'world'}
+
+
+def test_binary_response():
+    app = App(routes=[Route('/', 'GET', binary_response)])
+    client = TestClient(app)
+    response = client.get('http://example.com/')
+    assert response.text == '<html><h1>Hello, world</h1></html>'
+    assert response.headers['Content-Type'] == 'text/html; charset=utf-8'
+
+
+def test_text_response():
+    app = App(routes=[Route('/', 'GET', text_response)])
+    client = TestClient(app)
+    response = client.get('http://example.com/')
+    assert response.text == '<html><h1>Hello, world</h1></html>'
+    assert response.headers['Content-Type'] == 'text/html; charset=utf-8'
+
+
+def test_data_response():
+    app = App(routes=[Route('/', 'GET', data_response)])
+    client = TestClient(app)
+    response = client.get('http://example.com/')
+    assert response.json() == {'hello': 'world'}
+    assert response.headers['Content-Type'] == 'application/json'


### PR DESCRIPTION
Allow views to return either textual types (treated as HTML) or data types (treated as JSON).

There will probably be further iteration on this, and we *might* roll back some of the implicit behavior, but let's work towards some of the things we'll need to get nice API docs rendering.