### PR TITLE
Omit QUERY_STRING from wsgi environ when no query string is included

### DIFF
--- a/apistar/http.py
+++ b/apistar/http.py
@@ -63,7 +63,8 @@ class Path(str):
 class QueryString(str):
     @classmethod
     def build(cls, environ: WSGIEnviron):
-        return cls(environ['QUERY_STRING'])
+        query_string = environ.get('QUERY_STRING', '')
+        return cls(query_string)
 
 
 class URL(str):

--- a/apistar/test.py
+++ b/apistar/test.py
@@ -50,9 +50,11 @@ class WSGIAdapter(requests.adapters.HTTPAdapter):
             'wsgi.url_scheme': url_components.scheme,
             'SCRIPT_NAME': self.root_path,
             'PATH_INFO': url_components.path,
-            'QUERY_STRING': url_components.query,
             'wsgi.input': io.BytesIO(body)
         }
+
+        if url_components.query:
+            environ['QUERY_STRING'] = url_components.query
 
         if url_components.port:
             environ['SERVER_NAME'] = url_components.hostname

--- a/tests/test_wsgi.py
+++ b/tests/test_wsgi.py
@@ -35,7 +35,6 @@ def test_wsgi_environ():
         'HTTP_HOST': 'example.com',
         'HTTP_USER_AGENT': 'requests_client',
         'PATH_INFO': '/wsgi_environ/',
-        'QUERY_STRING': '',
         'REQUEST_METHOD': 'GET',
         'SCRIPT_NAME': '',
         'wsgi.input': None,


### PR DESCRIPTION
Note http://wsgi.readthedocs.io/en/latest/definitions.html

> **QUERY_STRING** - The portion of the request URL that follows the ”?”, if any. May be empty or absent.

Now omitting the `QUERY_STRING` from our test client when non is present, and handling that case correctly in `http.QueryString` and `http.QueryParams`