### PR TITLE
Command routing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,5 +13,5 @@ script:
     - scripts/lint
     - scripts/test
 
-after_success:
+after_script:
     - codecov

--- a/apistar/app.py
+++ b/apistar/app.py
@@ -111,7 +111,7 @@ def get_click_client(app):
                 kwargs['type'] = click.Choice(annotation.choices)
             elif hasattr(annotation, 'native_type'):
                 kwargs['type'] = annotation.native_type
-            elif inspect.Signature.empty:
+            elif annotation is inspect.Signature.empty:
                 kwargs['type'] = str
             else:
                 kwargs['type'] = annotation

--- a/apistar/commands/__init__.py
+++ b/apistar/commands/__init__.py
@@ -1,3 +1,5 @@
-from apistar.commands.base import new, run, test
+from apistar.commands.new import new
+from apistar.commands.run import run
+from apistar.commands.test import test
 
 __all__ = ['new', 'run', 'test']

--- a/apistar/commands/new.py
+++ b/apistar/commands/new.py
@@ -7,7 +7,6 @@ import click
 import apistar
 from apistar import schema
 
-
 APISTAR_PACKAGE_DIR = os.path.dirname(apistar.__file__)
 LAYOUTS_DIR = os.path.join(APISTAR_PACKAGE_DIR, 'layouts')
 LAYOUT_CHOICES = os.listdir(LAYOUTS_DIR)

--- a/apistar/commands/new.py
+++ b/apistar/commands/new.py
@@ -3,15 +3,13 @@ import shutil
 import sys
 
 import click
-import pytest
-from werkzeug.serving import is_running_from_reloader, run_simple
 
 import apistar
 from apistar import schema
-from apistar.exceptions import ConfigurationError
 
-ROOT_DIR = os.path.dirname(apistar.__file__)
-LAYOUTS_DIR = os.path.join(ROOT_DIR, 'layouts')
+
+APISTAR_PACKAGE_DIR = os.path.dirname(apistar.__file__)
+LAYOUTS_DIR = os.path.join(APISTAR_PACKAGE_DIR, 'layouts')
 LAYOUT_CHOICES = os.listdir(LAYOUTS_DIR)
 
 
@@ -53,45 +51,3 @@ def new(target_dir: TargetDir, layout: Layout, force: Force):
         if parent:
             os.makedirs(parent, exist_ok=True)
         shutil.copy(source_path, target_path)
-
-
-class Host(schema.String):
-    description = 'The host of the webserver.'
-    default = 'localhost'
-
-
-class Port(schema.Integer):
-    description = 'The port of the webserver.'
-    default = 8080
-
-
-def run(host: Host, port: Port):  # pragma: nocover
-    """
-    Run the current app.
-    """
-    from apistar.main import get_current_app
-    app = get_current_app()
-
-    try:
-        if not is_running_from_reloader():
-            click.echo('Starting up...')
-        run_simple(host, port, app.wsgi, use_reloader=True, use_debugger=True, extra_files=['app.py'])
-    except KeyboardInterrupt:
-        pass
-
-
-def test():
-    """
-    Run the test suite.
-    """
-    file_or_dir = []
-    if os.path.exists('tests'):
-        file_or_dir.append('tests')
-    if os.path.exists('tests.py'):
-        file_or_dir.append('tests.py')
-    if not file_or_dir:
-        raise ConfigurationError("No 'tests/' directory or 'tests.py' module.")
-
-    exitcode = pytest.main(list(file_or_dir))
-    if exitcode:
-        sys.exit(exitcode)

--- a/apistar/commands/run.py
+++ b/apistar/commands/run.py
@@ -1,0 +1,29 @@
+import click
+from werkzeug.serving import is_running_from_reloader, run_simple
+
+from apistar import schema
+
+
+class Host(schema.String):
+    description = 'The host of the webserver.'
+    default = 'localhost'
+
+
+class Port(schema.Integer):
+    description = 'The port of the webserver.'
+    default = 8080
+
+
+def run(host: Host, port: Port):  # pragma: nocover
+    """
+    Run the current app.
+    """
+    from apistar.main import get_current_app
+    app = get_current_app()
+
+    try:
+        if not is_running_from_reloader():
+            click.echo('Starting up...')
+        run_simple(host, port, app.wsgi, use_reloader=True, use_debugger=True, extra_files=['app.py'])
+    except KeyboardInterrupt:
+        pass

--- a/apistar/commands/test.py
+++ b/apistar/commands/test.py
@@ -1,0 +1,23 @@
+import os
+import sys
+
+import pytest
+
+from apistar.exceptions import ConfigurationError
+
+
+def test():
+    """
+    Run the test suite.
+    """
+    file_or_dir = []
+    if os.path.exists('tests'):
+        file_or_dir.append('tests')
+    if os.path.exists('tests.py'):
+        file_or_dir.append('tests.py')
+    if not file_or_dir:
+        raise ConfigurationError("No 'tests/' directory or 'tests.py' module.")
+
+    exitcode = pytest.main(list(file_or_dir))
+    if exitcode:
+        sys.exit(exitcode)

--- a/apistar/routing.py
+++ b/apistar/routing.py
@@ -72,7 +72,7 @@ class Router(object):
             werkzeug_path = path[:]
             for arg in uritemplate.variable_names:
                 param = view_signature.parameters[arg]
-                if param.annotation == inspect.Signature.empty:
+                if param.annotation is inspect.Signature.empty:
                     converter = 'string'
                 elif issubclass(param.annotation, (schema.String, str)):
                     converter = 'string'

--- a/apistar/schema.py
+++ b/apistar/schema.py
@@ -27,6 +27,7 @@ def validate(schema, value):
 
 
 class String(str):
+    native_type = str
     errors = {
         'blank': 'Must not be blank.',
         'max_length': 'Must have no more than {max_length} characters.',
@@ -69,7 +70,7 @@ class _NumericType(object):
     """
     Base class for both `Number` and `Integer`.
     """
-    _numeric_type = None  # type: type
+    native_type = None  # type: type
     errors = {
         'type': 'Must be a valid number.',
         'minimum': 'Must be greater than or equal to {minimum}.',
@@ -88,7 +89,7 @@ class _NumericType(object):
         assert len(args) == 1 and not kwargs
         value = args[0]
         try:
-            value = cls._numeric_type.__new__(cls, value)
+            value = cls.native_type.__new__(cls, value)
         except (TypeError, ValueError):
             raise SchemaError(cls, 'type')
 
@@ -120,14 +121,15 @@ class _NumericType(object):
 
 
 class Number(_NumericType, float):
-    _numeric_type = float
+    native_type = float
 
 
 class Integer(_NumericType, int):
-    _numeric_type = int
+    native_type = int
 
 
 class Boolean(object):
+    native_type = bool
     errors = {
         'type': 'Must be a valid boolean.'
     }

--- a/scripts/test
+++ b/scripts/test
@@ -7,10 +7,10 @@ fi
 
 export COVERAGE_FLAGS=""
 if [ "$TRAVIS" != "true" ] ; then
-    # Locally only display the coverage report once all tests are passing.
-    export COVERAGE_FLAGS="--no-cov-on-fail"
+    # Locally we enforce 100% coverage, once all tests are passing.
+    export COVERAGE_FLAGS="--no-cov-on-fail --cov-fail-under=100"
 fi
 
 set -x
 
-PYTHONPATH=. ${PREFIX}pytest --ignore venv --ignore apistar/layouts --cov=apistar --cov=tests --cov-fail-under=100 --cov-report=term-missing ${COVERAGE_FLAGS} ${@}
+PYTHONPATH=. ${PREFIX}pytest --ignore venv --ignore apistar/layouts --cov=apistar --cov=tests --cov-report=term-missing ${COVERAGE_FLAGS} ${@}

--- a/scripts/test
+++ b/scripts/test
@@ -5,12 +5,13 @@ if [ -d 'venv' ] ; then
     export PREFIX="venv/bin/"
 fi
 
-export COVERAGE_FLAGS=""
+export EXTRA_COVERAGE_FLAGS=""
 if [ "$TRAVIS" != "true" ] ; then
+    # If we're on travis we'll allow codecov to handle coverage pass/fail.
     # Locally we enforce 100% coverage, once all tests are passing.
-    export COVERAGE_FLAGS="--no-cov-on-fail --cov-fail-under=100"
+    export EXTRA_COVERAGE_FLAGS="--cov-fail-under=100 --no-cov-on-fail"
 fi
 
 set -x
 
-PYTHONPATH=. ${PREFIX}pytest --ignore venv --ignore apistar/layouts --cov=apistar --cov=tests --cov-report=term-missing ${COVERAGE_FLAGS} ${@}
+PYTHONPATH=. ${PREFIX}pytest --ignore venv --ignore apistar/layouts --cov=apistar --cov=tests --cov-report=term-missing ${EXTRA_COVERAGE_FLAGS} ${@}

--- a/scripts/test
+++ b/scripts/test
@@ -6,14 +6,11 @@ if [ -d 'venv' ] ; then
 fi
 
 export COVERAGE_FLAGS=""
-if [ "$TRAVIS" = "true" ] ; then
-    # On travis we always upload the coverage report, and allow
-    export COVERAGE_FLAGS="--cov-report=xml"
-else
-    # Locally we enforce 100% coverage if all tests are passing.
-    export COVERAGE_FLAGS="--cov-fail-under=100 --no-cov-on-fail"
+if [ "$TRAVIS" != "true" ] ; then
+    # Locally only display the coverage report once all tests are passing.
+    export COVERAGE_FLAGS="--no-cov-on-fail"
 fi
 
 set -x
 
-PYTHONPATH=. ${PREFIX}pytest --ignore venv --ignore apistar/layouts --cov=apistar --cov=tests --cov-report=term-missing ${COVERAGE_FLAGS} ${@}
+PYTHONPATH=. ${PREFIX}pytest --ignore venv --ignore apistar/layouts --cov=apistar --cov=tests --cov-fail-under=100 --cov-report=term-missing ${COVERAGE_FLAGS} ${@}

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,5 +1,6 @@
-import click
 import os
+
+import click
 
 from apistar import __version__, exceptions
 from apistar.app import App
@@ -43,7 +44,7 @@ def test_custom_command():
 
 def test_custom_command_with_int_arguments():
     def add(a: int, b: int):
-        click.echo(a + b)
+        click.echo(str(a + b))
 
     app = App(commands=[add])
     runner = CommandLineRunner(app)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,3 +1,4 @@
+import click
 import os
 
 from apistar import __version__, exceptions
@@ -22,6 +23,36 @@ def test_help_flag():
 def test_version_flag():
     result = runner.invoke(['--version'])
     assert __version__ in result.output
+    assert result.exit_code == 0
+
+
+def test_custom_command():
+    def custom(var):
+        click.echo(var)
+
+    app = App(commands=[custom])
+    runner = CommandLineRunner(app)
+
+    result = runner.invoke([])
+    assert 'custom' in result.output
+
+    result = runner.invoke(['custom', '123'])
+    assert result.output == '123\n'
+    assert result.exit_code == 0
+
+
+def test_custom_command_with_int_arguments():
+    def add(a: int, b: int):
+        click.echo(a + b)
+
+    app = App(commands=[add])
+    runner = CommandLineRunner(app)
+
+    result = runner.invoke([])
+    assert 'add' in result.output
+
+    result = runner.invoke(['add', '1', '2'])
+    assert result.output == '3\n'
     assert result.exit_code == 0
 
 


### PR DESCRIPTION
Routing functions as commands.

Still remaining:

- [x] Tests for custom commands.
- [x] Coverage for unannotated and plain types.
- [ ] Documentation.
- [ ] Handle responses, using echo.
- [ ] Replace sys.exit with some handled exception.
- [ ] Replace click.echo with a console component.
- [x] Refactor layout of commands.
- [ ] Refactor layout of tests.