### PR TITLE
Add 'Setting' component

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,53 @@ explicit `Content-Type` header.
 
 ---
 
+# Settings
+
+Application settings are configured at the point of instantiating the app.
+
+
+```python
+routes = [...]
+
+settings = {
+    'TEMPLATES': {
+        'TEMPLATE_DIR': '/foo/bar'
+    }
+}
+
+app = App(routes=routes, settings=settings)
+```
+
+You can include the application settings in a view, by using the `Settings`
+type annotation:
+
+```python
+from apistar.settings import Settings
+
+
+def debug_settings(settings: Settings):
+    """
+    Return a JSON response containing the application settings dictionary.
+    """
+    return settings
+```
+
+Similarly you can include a single application setting:
+
+```python
+def debug_template_settings(TEMPLATES: Setting):
+    """
+    Return a JSON response containing the application settings dictionary.
+    """
+    return {'TEMPLATES': TEMPLATES}
+```
+
+More typically you'll want to include settings into the `build` method of
+custom components, so that you can control their initialization, based on the
+application settings.
+
+---
+
 # Testing
 
 API Star includes the `py.test` testing framework. You can run all tests in
@@ -299,6 +346,7 @@ Component              | Description
 `routing.URLPathArgs`  | A dictionary containing all the matched URL path arguments.
 `routing.URLPathArg`   | A single URL path argument, corresponding to the keyword argument name. Automatically used for data arguments with a matching URL path component.
 `settings.Settings`    | A dictionary containing the application settings.
+`settings.Setting`     | A single named setting, as determined by the argument name.
 `templating.Templates` | The template environment.
 `templating.Template`  | A single loaded template, as determined by the argument name.
 `wsgi.Environ`         | The WSGI environ of the incoming request.

--- a/apistar/__init__.py
+++ b/apistar/__init__.py
@@ -9,8 +9,10 @@ from apistar.app import App
 from apistar.http import Request, Response
 from apistar.routing import Route
 from apistar.templating import Template, Templates
+from apistar.test import TestClient
+
 
 __version__ = '0.1.9'
 __all__ = [
-    'App', 'Route', 'Request', 'Response', 'Template', 'Templates'
+    'App', 'Route', 'Request', 'Response', 'Template', 'Templates', 'TestClient'
 ]

--- a/apistar/main.py
+++ b/apistar/main.py
@@ -7,7 +7,6 @@ import sys
 
 import click
 
-from apistar import App
 from apistar.exceptions import ConfigurationError
 
 sys.dont_write_bytecode = True
@@ -38,6 +37,8 @@ def setup_pythonpath():
 
 
 def main():  # pragma: no cover
+    from apistar import App
+
     setup_pythonpath()
     app_path = get_app_path()
     if os.path.exists(app_path):

--- a/apistar/settings.py
+++ b/apistar/settings.py
@@ -1,7 +1,18 @@
 from apistar import app
+from apistar.pipelines import ArgName
 
 
 class Settings(dict):
     @classmethod
     def build(cls, app: app.App):
         return cls(app.settings)
+
+
+class Setting(object):
+    def __new__(cls, *args):
+        assert len(args) == 1
+        return args[0]
+
+    @classmethod
+    def build(cls, arg_name: ArgName, settings: Settings):
+        return settings.get(arg_name)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,47 @@
+from apistar import App, Route, TestClient
+from apistar.settings import Setting, Settings
+
+
+def get_settings(settings: Settings):
+    return settings
+
+
+def get_setting(ABC: Setting):
+    return {'ABC': ABC}
+
+
+routes = [
+    Route('/settings/', 'GET', get_settings),
+    Route('/setting/', 'GET', get_setting),
+]
+
+settings = {
+    'ABC': 123,
+    'XYZ': 456
+}
+
+app = App(routes=routes, settings=settings)
+
+client = TestClient(app)
+
+
+def test_settings():
+    response = client.get('/settings/')
+    assert response.status_code == 200
+    assert response.json() == {
+        'ABC': 123,
+        'XYZ': 456
+    }
+
+
+def test_setting():
+    response = client.get('/setting/')
+    assert response.status_code == 200
+    assert response.json() == {
+        'ABC': 123,
+    }
+
+
+def test_use_setting_as_argument():
+    abc = Setting(789)
+    assert get_setting(abc) == {'ABC': 789}


### PR DESCRIPTION
Closes #84.

Some things we *might* re-open for later...

* validating the structure of settings
* settings.lookup(...)
* configuration errors in places where we're currently using settings, if they're invalid. (ie. templates incorrectly configured)