### PR TITLE
Templating improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ routes = [
 
 settings = {
     'TEMPLATES': {
-        'TEMPLATE_DIR': os.path.join(ROOT_DIR, 'templates')
+        'DIRS': [os.path.join(ROOT_DIR, 'templates')]
     }
 }
 

--- a/apistar/routing.py
+++ b/apistar/routing.py
@@ -8,7 +8,7 @@ from uritemplate import URITemplate
 from werkzeug.routing import Map, Rule
 from werkzeug.serving import is_running_from_reloader
 
-from apistar import app, exceptions, http, pipelines, schema, wsgi
+from apistar import exceptions, http, pipelines, schema, wsgi
 from apistar.pipelines import ArgName, Pipeline
 
 # TODO: Path
@@ -49,9 +49,10 @@ RouterLookup = Tuple[Callable, Pipeline, URLPathArgs]
 
 
 class Router(object):
-    def __init__(self, routes: List[Route]) -> None:
+    def __init__(self, routes: List[Route], initial_types: List[type]=None) -> None:
         required_type = wsgi.WSGIResponse
-        initial_types = [app.App, wsgi.WSGIEnviron, URLPathArgs, Exception]
+        initial_types = initial_types or []
+        initial_types += [wsgi.WSGIEnviron, URLPathArgs, Exception]
 
         rules = []
         views = {}

--- a/apistar/templating.py
+++ b/apistar/templating.py
@@ -2,6 +2,7 @@ import os
 
 import jinja2
 
+from apistar.exceptions import ConfigurationError
 from apistar.pipelines import ArgName
 from apistar.settings import Settings
 
@@ -9,18 +10,30 @@ from apistar.settings import Settings
 class Templates(jinja2.Environment):
     @classmethod
     def build(cls, settings: Settings):
-        template_dir = settings.get(['TEMPLATES', 'TEMPLATE_DIR'])
-        return Templates(
-            loader=jinja2.FileSystemLoader(template_dir)
-        )
+        template_dirs = settings.get(['TEMPLATES', 'DIRS'])
+        if len(template_dirs) == 1:
+            loader = jinja2.FileSystemLoader(template_dirs[0])
+        else:
+            loader = jinja2.ChoiceLoader([
+                jinja2.FileSystemLoader(template_dir)
+                for template_dir in template_dirs
+            ])
+
+        return Templates(loader=loader)
 
 
 class Template(jinja2.Template):
-    suffix = '.html'
+    prefix = ''
+    suffixes = ['.html', '.txt']
     path_delimiter = '__'
 
     @classmethod
     def build(cls, arg_name: ArgName, templates: Templates):
         paths = arg_name.split(cls.path_delimiter)
-        path = os.path.join(*paths) + cls.suffix
-        return templates.get_template(path)
+        path = os.path.join(cls.prefix, *paths)
+        for suffix in cls.suffixes:
+            try:
+                return templates.get_template(path + suffix)
+            except jinja2.TemplateNotFound:
+                pass
+        raise ConfigurationError('No template found for "%s".' % arg_name)

--- a/apistar/templating.py
+++ b/apistar/templating.py
@@ -11,6 +11,7 @@ class Templates(jinja2.Environment):
     @classmethod
     def build(cls, settings: Settings):
         template_dirs = settings.get(['TEMPLATES', 'DIRS'])
+        loader = None  # type: jinja2.BaseLoader
         if len(template_dirs) == 1:
             loader = jinja2.FileSystemLoader(template_dirs[0])
         else:

--- a/tests/test_templating.py
+++ b/tests/test_templating.py
@@ -1,7 +1,10 @@
 import os
 import tempfile
 
+import pytest
+
 from apistar.app import App
+from apistar.exceptions import ConfigurationError
 from apistar.routing import Route
 from apistar.settings import Settings
 from apistar.templating import Template, Templates
@@ -31,7 +34,7 @@ def test_get_and_render_template():
 
         settings = Settings(
             TEMPLATES={
-                'TEMPLATE_DIR': tempdir
+                'DIRS': [tempdir]
             }
         )
         app = App(routes=routes, settings=settings)
@@ -50,7 +53,7 @@ def test_render_template():
 
         settings = Settings(
             TEMPLATES={
-                'TEMPLATE_DIR': tempdir
+                'DIRS': [tempdir]
             }
         )
         app = App(routes=routes, settings=settings)
@@ -59,3 +62,34 @@ def test_render_template():
 
         assert response.status_code == 200
         assert response.text == '<html><body>Hello, tom</body><html>'
+
+
+def test_multiple_dirs():
+    with tempfile.TemporaryDirectory() as tempdir1:
+        with tempfile.TemporaryDirectory() as tempdir2:
+
+            path = os.path.join(tempdir2, 'index.txt')
+            with open(path, 'w') as index:
+                index.write('Hello, {{ username }}.')
+
+            settings = Settings(
+                TEMPLATES={
+                    'DIRS': [tempdir1, tempdir2]
+                }
+            )
+            app = App(routes=routes, settings=settings)
+            client = TestClient(app)
+            response = client.get('/render_template/?username=tom')
+
+            assert response.status_code == 200
+            assert response.text == 'Hello, tom.'
+
+
+def test_template_not_found():
+    settings = Settings(
+        TEMPLATES={
+            'DIRS': []
+        }
+    )
+    with pytest.raises(ConfigurationError):
+        app = App(routes=routes, settings=settings)

--- a/tests/test_templating.py
+++ b/tests/test_templating.py
@@ -91,5 +91,7 @@ def test_template_not_found():
             'DIRS': []
         }
     )
+    app = App(routes=routes, settings=settings)
+    client = TestClient(app)
     with pytest.raises(ConfigurationError):
-        app = App(routes=routes, settings=settings)
+        client.get('/render_template/?username=tom')


### PR DESCRIPTION
Refs #82

Also refs #67 - the `App()` instantiation in `test_template_not_found` *ought* to raise a configuration error once we have preloaded components in place. As it stands it won't raise any error until the view is called. Going to use this as the first test case against which to implement the preloading.