### PR TITLE
attempt adding the annotation types to exceptions class #87

### DIFF
--- a/apistar/exceptions.py
+++ b/apistar/exceptions.py
@@ -1,5 +1,9 @@
+from typing import Union
+from apistar.schema import String, Number, Integer, Boolean
+
 class SchemaError(Exception):
-    def __init__(self, schema, code):
+
+    def __init__(self, schema: Union[String, Number, Integer, Boolean], code: str) -> None:
         self.schema = schema
         self.code = code
         msg = schema.errors[code].format(**schema.__dict__)
@@ -16,7 +20,7 @@ class APIException(Exception):
     default_status_code = 500
     default_message = 'Server error'
 
-    def __init__(self, status_code=None, message=None):
+    def __init__(self, status_code:int = None, message:str = None) -> None:
         self.status_code = self.default_status_code if (status_code is None) else status_code
         self.message = self.default_message if (message is None) else message
 

--- a/apistar/schema.py
+++ b/apistar/schema.py
@@ -1,9 +1,6 @@
 import re
 from typing import Any, Dict, List, Tuple, Union  # noqa
 
-from apistar.exceptions import SchemaError, ValidationError
-
-
 # TODO: Validation errors
 # TODO: Error on unknown attributes
 # TODO: allow_blank?
@@ -20,6 +17,7 @@ from apistar.exceptions import SchemaError, ValidationError
 
 
 def validate(schema, value):
+    from apistar.exceptions import SchemaError, ValidationError
     try:
         return schema(value)
     except SchemaError as exc:
@@ -42,6 +40,8 @@ class String(str):
     trim_whitespace = True
 
     def __new__(cls, *args, **kwargs):
+        from apistar.exceptions import SchemaError
+
         assert len(args) == 1 and not kwargs
         value = str.__new__(cls, *args)
 
@@ -86,6 +86,7 @@ class _NumericType(object):
     multiple_of = None  # type: Union[float, int]
 
     def __new__(cls, *args, **kwargs):
+        from apistar.exceptions import SchemaError
         assert len(args) == 1 and not kwargs
         value = args[0]
         try:
@@ -135,6 +136,8 @@ class Boolean(object):
     }
 
     def __new__(self, *args, **kwargs):
+        from apistar.exceptions import SchemaError
+
         assert len(args) == 1 and not kwargs
         value = args[0]
 


### PR DESCRIPTION
first crack at this, in order to make it work because of circular dependencies we defer imports in the `schema.py`