### PR TITLE
Type-annotate apistar.wsgi

### DIFF
--- a/apistar/pipelines.py
+++ b/apistar/pipelines.py
@@ -41,7 +41,7 @@ def parameterize_by_argument_name(cls: type) -> bool:
 def get_class_id(cls: type,
                  arg_name: str=None) -> str:
     # http://stackoverflow.com/questions/1175208/elegant-python-function-to-convert-camelcase-to-snake-case
-    name = cls.__name__
+    name = cls if type(cls) is str else cls.__name__
     s1 = FIRST_CAP_RE.sub(r'\1_\2', name)
     s2 = ALL_CAP_RE.sub(r'\1_\2', s1).lower()
     if parameterize_by_argument_name(cls):

--- a/apistar/pipelines.py
+++ b/apistar/pipelines.py
@@ -41,7 +41,7 @@ def parameterize_by_argument_name(cls: type) -> bool:
 def get_class_id(cls: type,
                  arg_name: str=None) -> str:
     # http://stackoverflow.com/questions/1175208/elegant-python-function-to-convert-camelcase-to-snake-case
-    name = cls if type(cls) is str else cls.__name__
+    name = str(cls) if type(cls) is str else cls.__name__
     s1 = FIRST_CAP_RE.sub(r'\1_\2', name)
     s2 = ALL_CAP_RE.sub(r'\1_\2', s1).lower()
     if parameterize_by_argument_name(cls):

--- a/apistar/wsgi.py
+++ b/apistar/wsgi.py
@@ -25,7 +25,7 @@ class WSGIResponse(object):
         self.iterator = iterator
 
     @classmethod
-    def build(cls, response: http.Response):
+    def build(cls, response: http.Response) -> 'WSGIResponse':
         try:
             status_text = STATUS_CODES[response.status]
         except KeyError:


### PR DESCRIPTION
When we want to annotate the return type of the `build` classmethods [PEP-484](https://www.python.org/dev/peps/pep-0484/#forward-references) suggest a string literal annotation like 
_... -> 'WSGIResponse'_

The tests showed, that this breaks `pipelines.get_class_id` so I also added a small change to fix this.

Is this the proper way to annotate the build classmethods and does it make sense?