### PR TITLE
Environment support

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,9 @@ explicit `Content-Type` header.
 
 ---
 
-# Settings
+# Settings & Environment
+
+## Application settings
 
 Application settings are configured at the point of instantiating the app.
 
@@ -253,6 +255,40 @@ def debug_template_settings(TEMPLATES: Setting):
 More typically you'll want to include settings into the `build` method of
 custom components, so that you can control their initialization, based on the
 application settings.
+
+## Environment
+
+Typically you'll want to follow the "twelve-factor app" pattern and [store
+configuration variables in the environment](https://12factor.net/config), rather
+than keeping them under source control.
+
+API Star provides an `Environment` class that allows you to load the environment,
+and ensure that it is correctly configured.
+
+```python
+from apistar import environment, schema
+
+
+class Env(environment.Environment):
+    properties = {
+        'DEBUG': schema.Boolean(default=False)
+        'DATABASE_URL': schema.String(default='sqlite://')
+    }
+
+env = Env()
+```
+
+Once you have an `Environment` instance, you can use it when creating
+the application settings.
+
+
+```python
+settings = {
+    'DATABASE': {
+        'URL': env['DATABASE_URL']
+    }
+}
+```
 
 ---
 
@@ -332,7 +368,6 @@ def create_customer(db: SQLAlchemy, name: str):
     session.commit()
     return {'name': name}
 ```
-
 
 ---
 

--- a/apistar/environment.py
+++ b/apistar/environment.py
@@ -1,11 +1,11 @@
 import os
-from typing import Dict, List  # noqa
+from typing import Any, Dict  # noqa
 
 from apistar import exceptions, schema
 
 
 class Environment(schema.Object):
-    properties = {}  # type: Dict[str, type]
+    properties = {}  # type: Dict[str, Any]
     _os_environ = os.environ
 
     def __new__(cls, *args):

--- a/apistar/environment.py
+++ b/apistar/environment.py
@@ -6,14 +6,14 @@ from apistar import exceptions, schema
 
 class Environment(schema.Object):
     properties = {}  # type: Dict[str, type]
-    required = []  # type: List[str]
+    _os_environ = os.environ
 
     def __new__(cls, *args):
         return dict.__new__(cls, *args)
 
     def __init__(self, value=None):
         if value is None:
-            value = os.environ
+            value = self._os_environ
 
         try:
             super().__init__(value)

--- a/apistar/environment.py
+++ b/apistar/environment.py
@@ -1,0 +1,21 @@
+import os
+from typing import Dict, List  # noqa
+
+from apistar import exceptions, schema
+
+
+class Environment(schema.Object):
+    properties = {}  # type: Dict[str, type]
+    required = []  # type: List[str]
+
+    def __new__(cls, *args):
+        return dict.__new__(cls, *args)
+
+    def __init__(self, value=None):
+        if value is None:
+            value = os.environ
+
+        try:
+            super().__init__(value)
+        except exceptions.SchemaError as exc:
+            raise exceptions.ConfigurationError(exc.detail)

--- a/apistar/schema.py
+++ b/apistar/schema.py
@@ -1,5 +1,5 @@
 import re
-from typing import Any, Dict, List, Tuple, Union  # noqa
+from typing import Any, Dict, List, Tuple, Type, Union  # noqa
 
 from apistar.exceptions import SchemaError, ValidationError
 

--- a/apistar/schema.py
+++ b/apistar/schema.py
@@ -234,6 +234,9 @@ class Object(dict):
                     if hasattr(child_schema, 'default'):
                         # If a key is missing but has a default, then use that.
                         self[key] = child_schema.default
+                    else:
+                        errors[key] = error_message(self, 'required')
+
                 else:
                     # Coerce value into the given schema type if needed.
                     if isinstance(item, child_schema):

--- a/tests/schema/test_object.py
+++ b/tests/schema/test_object.py
@@ -15,7 +15,7 @@ class HighScore(schema.Object):
     properties = {
         'name': schema.String(max_length=100),
         'score': schema.Integer(minimum=0, maximum=100),
-        'completed': schema.Boolean,
+        'completed': schema.Boolean(default=False),
         'difficulty': schema.Enum(enum=['easy', 'medium', 'hard']),
         'location': Location(default={'latitude': 0.0, 'longitude': 0.0})
     }
@@ -38,6 +38,7 @@ def test_valid_object():
     response = client.post('/basic_object/', json={
         'name': 'tom',
         'score': 87,
+        'difficulty': 'easy',
         'completed': True,
         'location': {
             'latitude': 51.477,
@@ -48,6 +49,7 @@ def test_valid_object():
     assert response.json() == {
         'name': 'tom',
         'score': 87,
+        'difficulty': 'easy',
         'completed': True,
         'location': {
             'latitude': 51.477,
@@ -71,13 +73,26 @@ def test_invalid_object():
 
 class test_object_instantiation():
     location = Location({'latitude': 51.477, 'longitude': 0.0})
-    value = HighScore({'name': 'tom', 'location': location})
+    value = HighScore({
+        'name': 'tom',
+        'score': 99.0,
+        'difficulty': 'easy',
+        'completed': 'True',
+        'location': location
+    })
     assert value['name'] == 'tom'
+    assert value['score'] == 99
+    assert value['completed'] is True
     assert value['location'] == location
 
 
 class test_object_default():
-    value = HighScore({'name': 'tom'})
+    value = HighScore({
+        'name': 'tom',
+        'score': 99,
+        'difficulty': 'easy',
+        'completed': True
+    })
     assert value['location'] == {'latitude': 0.0, 'longitude': 0.0}
 
 

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -1,0 +1,50 @@
+import os
+import pytest
+
+from apistar import environment, exceptions, schema
+
+
+class Env(environment.Environment):
+    properties = {
+        'DEBUG': schema.Boolean(default=False),
+        'DATABASE_URL': schema.String
+    }
+
+
+def test_valid_env():
+    env = Env({
+        'DEBUG': 'False',
+        'DATABASE_URL': 'sqlite:///test.db'
+    })
+    assert env['DEBUG'] is False
+    assert env['DATABASE_URL'] == 'sqlite:///test.db'
+
+
+def test_env_missing_optional():
+    env = Env({
+        'DATABASE_URL': 'sqlite:///test.db'
+    })
+    assert env['DEBUG'] is False
+    assert env['DATABASE_URL'] == 'sqlite:///test.db'
+
+
+def test_env_missing_required():
+    with pytest.raises(exceptions.ConfigurationError):
+        env = Env({})
+
+
+def test_os_environ():
+    """
+    The usual invokation is to call the class with no arguments.
+    In this case `os.environ` should be used as the instantiation value.
+    We inject a mock environment here to test this case.
+    """
+    class TestEnv(Env):
+        _os_environ = {
+            'DEBUG': 'FALSE',
+            'DATABASE_URL': 'sqlite:///test.db'
+        }
+
+    env = TestEnv()
+    assert env['DEBUG'] is False
+    assert env['DATABASE_URL'] == 'sqlite:///test.db'

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -1,4 +1,3 @@
-import os
 import pytest
 
 from apistar import environment, exceptions, schema
@@ -30,7 +29,9 @@ def test_env_missing_optional():
 
 def test_env_missing_required():
     with pytest.raises(exceptions.ConfigurationError):
-        env = Env({})
+        Env({
+            'DEBUG': 'False'
+        })
 
 
 def test_os_environ():


### PR DESCRIPTION
Closes #83.

More minimal approach than #112.
We'll start off by *not* supporting a `.env` file.