### PR TITLE
Add support for parsing form data

### DIFF
--- a/apistar/exceptions.py
+++ b/apistar/exceptions.py
@@ -35,3 +35,8 @@ class NotFound(APIException):
 class MethodNotAllowed(APIException):
     default_status_code = 405
     default_detail = 'Method not allowed'
+
+
+class UnsupportedMediaType(APIException):
+    default_status_code = 415
+    default_detail = 'Unsupported media type in request'

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -186,6 +186,19 @@ def test_data():
     response = client.post('http://example.com/data/', json={"hello": 123})
     assert response.json() == {'data': {"hello": 123}}
 
+    response = client.post('http://example.com/data/')
+    assert response.json() == {'data': None}
+
+    response = client.post('http://example.com/data/', data={'abc': 123})
+    assert response.json() == {'data': {'abc': ['123']}}
+
+    files = {'file': ('report.csv', '1,2,3\n4,5,6\n')}
+    response = client.post('http://example.com/data/', files=files)
+    assert response.json() == {'data': {'file': [['1,2,3\n', '4,5,6\n']]}}
+
+    response = client.post('http://example.com/data/', headers={'content-type': 'unknown'})
+    assert response.status_code == 415
+
 
 def test_headers():
     response = client.get('http://example.com/headers/')


### PR DESCRIPTION
`RequestData` now parses form data as well as JSON.

Closes #79.