### PR TITLE
Type annotate apistar.exceptions

### DIFF
--- a/apistar/exceptions.py
+++ b/apistar/exceptions.py
@@ -1,4 +1,4 @@
-from typing import Any, Union
+from typing import Union
 
 
 class ConfigurationError(Exception):
@@ -26,9 +26,9 @@ class Found(APIException):
     default_status_code = 302
     default_detail = ''
 
-    def __init__(self, location: str, *args: Any, **kwargs: Any) -> None:
+    def __init__(self, location: str, detail: Union[str, dict]=None, status_code: int=None) -> None:
         self.location = location
-        super().__init__(*args, **kwargs)
+        super().__init__(detail, status_code)
 
 
 class ValidationError(APIException):

--- a/apistar/exceptions.py
+++ b/apistar/exceptions.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Union, Any
 
 
 class ConfigurationError(Exception):
@@ -26,7 +26,7 @@ class Found(APIException):
     default_status_code = 302
     default_detail = ''
 
-    def __init__(self, location, *args, **kwargs):
+    def __init__(self, location: str, *args: Any, **kwargs: Any) -> None:
         self.location = location
         super().__init__(*args, **kwargs)
 

--- a/apistar/exceptions.py
+++ b/apistar/exceptions.py
@@ -1,4 +1,4 @@
-from typing import Union, Any
+from typing import Any, Union
 
 
 class ConfigurationError(Exception):


### PR DESCRIPTION
kwargs could probably be annotated more concrete than `Any`, eg. `Union[str, dict, int]` (since that are the currently only possible kwargs in APIException), however this raises the following errors:

```
apistar/exceptions.py:31: error: Argument 2 to "__init__" of "APIException" has incompatible type **Dict[str, Union[str, Dict[Any, Any], int]]; expected "Union[str, Dict[Any, Any]]"
apistar/exceptions.py:31: error: Argument 2 to "__init__" of "APIException" has incompatible type **Dict[str, Union[str, Dict[Any, Any], int]]; expected "int"
```
This seems related to an issue with mypy: https://github.com/python/mypy/issues/1969

That's why I went with `Any` for the kwargs. I hope this is helpful 😊 

Related issue #87 