### PR TITLE
fix: Adding dist dir to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ __pycache__
 /build
 coverage.xml
 test.db
+dist/

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,6 @@ __pycache__
 /htmlcov
 /venv
 /build
+/dist
 coverage.xml
 test.db
-dist/


### PR DESCRIPTION
This was missing from the gitignore. I do not want to accidentally commit this one. 