### PR TITLE
Make ujson optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -655,6 +655,8 @@ A pull request [has been issued](https://github.com/TechEmpower/FrameworkBenchma
 to add API Star to future rounds of the TechEmpower benchmarks. In the future we
 plan to be adding more realistic & useful test types, such as database query performance.
 
+API Star optionally supports the `ujson` package for improvements in serialization performance. Currently `ujson` will automatically be used if the package is installed.
+
 ---
 
 # Deployment

--- a/apistar/__init__.py
+++ b/apistar/__init__.py
@@ -11,7 +11,7 @@ from apistar.routing import Route
 from apistar.templating import Template, Templates
 from apistar.test import TestClient
 
-__version__ = '0.1.14'
+__version__ = '0.1.15'
 __all__ = [
     'App', 'Route', 'Request', 'Response', 'Template', 'Templates', 'TestClient'
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ coreapi
 jinja2
 pytest
 requests
-ujson
 werkzeug
 
 # Optional

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,6 @@ setup(
         'jinja2',
         'pytest',
         'requests',
-        'ujson',
         'werkzeug'
     ],
     classifiers=[

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -169,7 +169,7 @@ def test_invalid_integer():
 
 
 def test_misconfigured_route():
-    def set_type(var: set):  # pragma: nocover
+    def set_type(var: set):  # pragma: nocover  (We never actually call this handler)
         pass
 
     with pytest.raises(exceptions.ConfigurationError):


### PR DESCRIPTION
I've made `ujson` into an optional dependency, that's no longer installed by default.
I've also removed it from the development requirements. I think it makes more sense to test *without* ujson by default, since the handling of types by the standard lib is stricter and more correct. We're far less likely to have differences between running the tests with/without ujson if we target the stricter case. (Failures before were due to ujson's non-complience when handling unserializable datatypes that *ought* to raise an error)

Closes #129.
Closes #126.