### PR TITLE
First pass at generating API Schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ A smart Web API framework, designed for Python 3.
 - [Schemas](#schemas)
     - [Data Validation](#data-validation)
     - [Serialization](#serialization)
+    - [Generating API Schemas](#generating-api-schemas)
 - [Templates](#templates)
 - [Settings & Environment](#settings--environment)
     - [Application settings](#application-settings)
@@ -286,6 +287,38 @@ Validates dictionary or object input. A subclass of `dict`.
 * `properties` - A dictionary mapping string key names to schema or type values.
 
 Note that child properties are considered to be required if they do not have a `default` value.
+
+## Generating API Schemas
+
+API Star is designed to be able to map well onto API description formats, known as "API Schemas".
+
+There is currently provisional support for writing Swagger, RAML, or CoreJSON schemas.
+
+The default output format is the built-in CoreJSON support:
+
+```shell
+$ apistar schema
+{"_type":"document", ...}
+```
+
+The OpenAPI (Swagger) and RAML codecs are optional, and require installation of additional packages:
+
+#### Swagger
+
+```shell
+$ pip install openapi-codec
+$ apistar schema --format openapi
+{"swagger": "2.0", "info": ...}
+```
+
+#### RAML
+
+```shell
+$ pip install raml-codec
+$ apistar schema --format raml
+#%RAML 0.8
+...
+```
 
 ---
 

--- a/apistar/apischema.py
+++ b/apistar/apischema.py
@@ -1,11 +1,11 @@
 import inspect
 
+from coreapi import Document, Field, Link
 from uritemplate import URITemplate
 
-from apistar import http, schema
+from apistar import schema
 from apistar.app import App
 from apistar.routing import primitive_types, schema_types
-from coreapi import Document, Field, Link
 
 
 class APISchema(Document):

--- a/apistar/apischema.py
+++ b/apistar/apischema.py
@@ -1,0 +1,51 @@
+import inspect
+
+from uritemplate import URITemplate
+
+from apistar import http, schema
+from apistar.app import App
+from apistar.routing import primitive_types, schema_types
+from coreapi import Document, Field, Link
+
+
+class APISchema(Document):
+    @classmethod
+    def build(cls, app: App):
+        content = {}
+
+        for (path, method, view) in app.routes:
+            view_signature = inspect.signature(view)
+            uritemplate = URITemplate(path)
+            name = view.__name__
+
+            fields = []
+            for param in view_signature.parameters.values():
+
+                if param.annotation is inspect.Signature.empty:
+                    annotated_type = str
+                else:
+                    annotated_type = param.annotation
+
+                location = None
+                required = False
+                if param.name in uritemplate.variable_names:
+                    location = 'path'
+                    required = True
+                elif (annotated_type in primitive_types) or issubclass(annotated_type, schema_types):
+                    if method in ('POST', 'PUT', 'PATCH'):
+                        if issubclass(annotated_type, schema.Object):
+                            location = 'body'
+                            required = True
+                        else:
+                            location = 'form'
+                    else:
+                        location = 'query'
+
+                if location is not None:
+                    field = Field(name=param.name, location=location, required=required)
+                    fields.append(field)
+
+            link = Link(url=path, action=method, fields=fields)
+            content[name] = link
+
+        return cls(content=content)

--- a/apistar/app.py
+++ b/apistar/app.py
@@ -14,6 +14,7 @@ class App(object):
     built_in_commands = (
         cmd.new,
         cmd.run,
+        cmd.schema,
         cmd.test,
     )
 

--- a/apistar/commands/__init__.py
+++ b/apistar/commands/__init__.py
@@ -1,6 +1,7 @@
 from apistar.commands.create_tables import create_tables
 from apistar.commands.new import new
 from apistar.commands.run import run
+from apistar.commands.schema import schema
 from apistar.commands.test import test
 
-__all__ = ['new', 'run', 'test', 'create_tables']
+__all__ = ['new', 'run', 'schema', 'test', 'create_tables']

--- a/apistar/commands/schema.py
+++ b/apistar/commands/schema.py
@@ -1,0 +1,30 @@
+import click
+
+from coreapi.utils import get_installed_codecs
+
+from apistar import schema
+
+
+codecs = {
+    name: codec for name, codec in get_installed_codecs().items()
+    if '+' in codec.media_type
+}
+
+
+class Format(schema.String):
+    description = 'The format for the API Schema output.'
+    default = 'corejson'
+    choices = list(codecs.keys())
+
+
+def schema(format: Format) -> None:  # pragma: nocover
+    """
+    Output an API Schema.
+    """
+    from apistar.main import get_current_app
+    from apistar.apischema import APISchema
+    app = get_current_app()
+    schema = APISchema.build(app)
+    codec = codecs[format]
+    output = codec.encode(schema)
+    click.echo(output)

--- a/apistar/routing.py
+++ b/apistar/routing.py
@@ -12,7 +12,6 @@ from werkzeug.serving import is_running_from_reloader
 from apistar import exceptions, http, pipelines, schema, wsgi
 from apistar.pipelines import ArgName, Pipeline
 
-
 primitive_types = (
     str, int, float, bool, list, dict
 )

--- a/apistar/schema.py
+++ b/apistar/schema.py
@@ -1,5 +1,5 @@
 import re
-from typing import Any, Dict, List, Tuple, Union  # noqa
+from typing import Any, Dict, List, Tuple, Union, overload  # noqa
 
 from apistar.exceptions import SchemaError, ValidationError
 
@@ -53,7 +53,7 @@ class String(str):
             return type(cls.__name__, (cls,), kwargs)
 
         assert len(args) == 1
-        value = str.__new__(cls, *args)
+        value = super().__new__(cls, *args)
 
         if cls.trim_whitespace:
             value = value.strip()
@@ -74,6 +74,13 @@ class String(str):
                 raise SchemaError(error_message(cls, 'pattern'))
 
         return value
+
+    # The following is currently required in order to keep mypy happy
+    # with our atypical usage of `__new__`...
+    # See: https://github.com/python/mypy/issues/3307
+
+    def __init__(self, *args, **kwargs):  # pragma: nocover
+        super().__init__()
 
 
 class _NumericType(object):
@@ -132,6 +139,13 @@ class _NumericType(object):
                 raise SchemaError(error_message(cls, 'multiple_of'))
 
         return value
+
+    # The following is currently required in order to keep mypy happy
+    # with our atypical usage of `__new__`...
+    # See: https://github.com/python/mypy/issues/3307
+
+    def __init__(self, *args, **kwargs):
+        super().__init__()
 
 
 class Number(_NumericType, float):
@@ -197,7 +211,7 @@ class Object(dict):
         'invalid_key': 'Object keys must be strings.',
         'required': 'This field is required.',
     }
-    properties = {}  # type: Dict[str, type]
+    properties = {}  # type: Dict[str, Any]
 
     def __new__(cls, *args, **kwargs):
         if kwargs:

--- a/tests/test_apischema.py
+++ b/tests/test_apischema.py
@@ -1,0 +1,70 @@
+from coreapi import Field, Link
+
+from apistar import schema
+from apistar.app import App
+from apistar.apischema import APISchema
+from apistar.routing import Route
+
+
+class ToDoNote(schema.Object):
+    properties = {
+        'id': schema.Integer(min_value=0),
+        'text': schema.String(max_length=100),
+        'complete': schema.Boolean
+    }
+
+
+def list_todo(app: App, search):  # pragma: nocover
+    pass
+
+
+def add_todo(note: ToDoNote):  # pragma: nocover
+    pass
+
+
+def show_todo(ident: int):  # pragma: nocover
+    pass
+
+
+def set_complete(ident: int, complete: bool):  # pragma: nocover
+    pass
+
+
+routes = [
+    Route('/todo/', 'GET', list_todo),
+    Route('/todo/', 'POST', add_todo),
+    Route('/todo/{ident}/', 'GET', show_todo),
+    Route('/todo/{ident}/', 'PUT', set_complete),
+]
+
+app = App(routes=routes)
+
+
+def test_api_schema():
+    schema = APISchema.build(app)
+    expected = APISchema(content={
+        'list_todo': Link(
+            url='/todo/',
+            action='GET',
+            fields=[Field(name='search', location='query', required=False)]
+        ),
+        'add_todo': Link(
+            url='/todo/',
+            action='POST',
+            fields=[Field(name='note', location='body', required=True)]
+        ),
+        'show_todo': Link(
+            url='/todo/{ident}/',
+            action='GET',
+            fields=[Field(name='ident', location='path', required=True)]
+        ),
+        'set_complete': Link(
+            url='/todo/{ident}/',
+            action='PUT',
+            fields=[
+                Field(name='ident', location='path', required=True),
+                Field(name='complete', location='form', required=False)
+            ]
+        )
+    })
+    assert schema == expected

--- a/tests/test_apischema.py
+++ b/tests/test_apischema.py
@@ -1,8 +1,8 @@
 from coreapi import Field, Link
 
 from apistar import schema
-from apistar.app import App
 from apistar.apischema import APISchema
+from apistar.app import App
 from apistar.routing import Route
 
 

--- a/tests/test_apischema.py
+++ b/tests/test_apischema.py
@@ -8,7 +8,7 @@ from apistar.routing import Route
 
 class ToDoNote(schema.Object):
     properties = {
-        'id': schema.Integer(min_value=0),
+        'id': schema.Integer(minimum=0),
         'text': schema.String(max_length=100),
         'complete': schema.Boolean
     }

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -133,3 +133,11 @@ def test_misconfigured_app_module():
         result = runner.invoke(['run'])
         assert isinstance(result.exception, exceptions.ConfigurationError)
         assert result.exit_code != 0
+
+
+def test_schema():
+    with runner.isolated_filesystem():
+        runner.invoke(['new', '.', '--layout', 'minimal'])
+        result = runner.invoke(['schema'])
+        assert result.exit_code == 0
+        assert result.output == '{"_type":"document","welcome":{"_type":"link","url":"/","action":"GET"}}\n'


### PR DESCRIPTION
Refs #69.

Remaining:

- [ ] Add descriptions to fields and links.
- [ ] Support direct usage of QueryParam, RequestData.
- [ ] Include proper type information in the API Schemas.
- [ ] Include response schemas.
- [ ] Allow for API structure, using includes.
- [ ] Allow for eg `_id` -> `id` in function arguments, to work around python keyword-clashes.
- [ ] Allow for explicit naming in `Route` to override automatic function naming.
- [ ] Figure out encodings on links.
- [ ] API Name
- [ ] API Description
- [ ] API Base URL
- [ ] Document usage of client libraries.