### PR TITLE
Database Backend

### DIFF
--- a/apistar/app.py
+++ b/apistar/app.py
@@ -5,7 +5,7 @@ from typing import Any, Callable, Dict, List
 import click
 
 from apistar import commands as cmd
-from apistar import pipelines, routing, schema, backends
+from apistar import backends, pipelines, routing, schema
 # from apistar.backends.utils import db_backend_loader
 
 DEFAULT_LOOKUP_CACHE_SIZE = 10000
@@ -42,7 +42,7 @@ class App(object):
             initial_types.append(Templates)
             self.preloaded['templates'] = Templates.build(self.settings)
         if 'DATABASE' in self.settings:
-            Backend = backends.utils.db_backend_loader(self.settings)
+            Backend = backends.db_backend_loader(self.settings)
             initial_types.append(Backend)
             self.preloaded[Backend.preload_key] = Backend.build(self.settings)
             self.commands += Backend.commands

--- a/apistar/backends/__init__.py
+++ b/apistar/backends/__init__.py
@@ -1,5 +1,5 @@
-from apistar.backends import sqlalchemy, base
+from apistar.backends import base, sqlalchemy
 from apistar.backends.sqlalchemy import SQLAlchemy
 from apistar.backends.utils import db_backend_loader
 
-__all__ = ['sqlalchemy', 'base', 'SQLAlchemy', 'db_backend_loader', ]
+__all__ = ['base', 'sqlalchemy', 'db_backend_loader', 'SQLAlchemy', ]

--- a/apistar/backends/__init__.py
+++ b/apistar/backends/__init__.py
@@ -1,3 +1,5 @@
+from apistar.backends import sqlalchemy, base
 from apistar.backends.sqlalchemy import SQLAlchemy
+from apistar.backends.utils import db_backend_loader
 
-__all__ = ['SQLAlchemy']
+__all__ = ['sqlalchemy', 'base', 'SQLAlchemy', 'db_backend_loader', ]

--- a/apistar/backends/base.py
+++ b/apistar/backends/base.py
@@ -1,0 +1,3 @@
+class BaseDatabaseBackend(object):
+    preload_key = None
+    commands = []

--- a/apistar/backends/base.py
+++ b/apistar/backends/base.py
@@ -1,3 +1,6 @@
+from typing import Any, List  # NOQA
+
+
 class BaseDatabaseBackend(object):
-    preload_key = None
-    commands = []
+    preload_key = ''
+    commands = []  # type: List[Any]

--- a/apistar/backends/sqlalchemy.py
+++ b/apistar/backends/sqlalchemy.py
@@ -1,8 +1,13 @@
-from apistar.settings import Settings
+# from apistar.settings import Settings
+from apistar import commands
+from apistar.backends.base import BaseDatabaseBackend
 
 
-class SQLAlchemy(object):
-    __slots__ = ('engine', 'session_class', 'metadata')
+class SQLAlchemy(BaseDatabaseBackend):
+    __slots__ = ('engine', 'session_class', 'metadata', )
+
+    preload_key = 'sql_alchemy'
+    commands = [commands.create_tables, ]
 
     def __init__(self, engine, session_class, metadata=None):
         self.engine = engine
@@ -10,7 +15,7 @@ class SQLAlchemy(object):
         self.metadata = metadata
 
     @classmethod
-    def build(cls, settings: Settings):
+    def build(cls, settings):
         config = settings['DATABASE']
         url = config['URL']
         metadata = config['METADATA']

--- a/apistar/backends/utils.py
+++ b/apistar/backends/utils.py
@@ -6,7 +6,7 @@ default_db_backend = 'apistar.backends.sqlalchemy.SQLAlchemy'
 
 def db_backend_loader(settings):
     database_settings = settings.get('DATABASE', {})
-    backend_name = database_settings.get('backend', default_db_backend)
+    backend_name = database_settings.get('BACKEND', default_db_backend)
 
     parts = backend_name.split('.')
     class_name = parts.pop()

--- a/apistar/backends/utils.py
+++ b/apistar/backends/utils.py
@@ -1,0 +1,17 @@
+import importlib
+
+
+default_db_backend = 'apistar.backends.sqlalchemy.SQLAlchemy'
+
+
+def db_backend_loader(settings):
+    database_settings = settings.get('DATABASE', {})
+    backend_name = database_settings.get('backend', default_db_backend)
+
+    parts = backend_name.split('.')
+    class_name = parts.pop()
+    module_name = '.'.join(parts)
+    module = importlib.import_module(module_name)
+    backend = getattr(module, class_name)
+
+    return backend


### PR DESCRIPTION
The attempt here is to *begin* to abstract away the database backends and ORMs. The main addition is a new method in `backends.db_backend_loader` that reads a string in the `settings`. It is set to load the existing `SQLAlchemy` backend by default.

Therefore, if your settings were (as in the example):

    settings = {
        "DATABASE": {
            "URL": "postgresql://:@localhost/apistar",
            "METADATA": Base.metadata
        }
    }

It would be implied as:

    settings = {
        "DATABASE": {
            "URL": "postgresql://:@localhost/apistar",
            "METADATA": Base.metadata,
            "BACKEND": "apistar.backends.sqlalchemy.SQLAlchemy"
        }
    }

The `SQLAlchemy` backend should otherwise function as existing. There are two new class level variables (`preload_key` and `commands`) to accomplish the same functionality as already existing in `App()`. Perhaps there will be a better method of handling down the road.

Lastly, there is the beginning of a `BaseDatabaseBackend` that can be used for further abstraction down the road.

One thing to note ... I **did** have to remove a type annotation in `backends.sqlalchemy.SQLAlchemy`. In the `build` method, I had to remove the annotation for the `settings` parameter because there was an instantiation of `settings` problem where the backend was being called before the `app.App` was created.