### PR TITLE
Preloading

### DIFF
--- a/apistar/app.py
+++ b/apistar/app.py
@@ -23,9 +23,6 @@ class App(object):
                  commands: List[Callable] = None,
                  settings: Dict[str, Any] = None) -> None:
         from apistar.settings import Settings
-        from apistar.statics import Statics
-        from apistar.templating import Templates
-        from apistar.backends.sqlalchemy import SQLAlchemy
 
         routes = [] if (routes is None) else routes
         commands = [] if (commands is None) else commands
@@ -38,19 +35,9 @@ class App(object):
         self.preloaded = {
             'app': self
         }
-        # preload_state(self.preloaded, self.routes)
-        print(self.preloaded)
-
-        if 'TEMPLATES' in self.settings:
-            initial_types.append(Templates)
-            self.preloaded['templates'] = Templates.build(self.settings)
-        if 'DATABASE' in self.settings:
-            initial_types.append(SQLAlchemy)
-            self.preloaded['sql_alchemy'] = SQLAlchemy.build(self.settings)
+        preload_state(self.preloaded, self.routes)
+        if 'sql_alchemy' in self.preloaded:
             self.commands += [cmd.create_tables]
-        if 'STATICS' in self.settings:
-            initial_types.append(Statics)
-            self.preloaded['statics'] = Statics.build(self.settings)
 
         self.router = routing.Router(self.routes, initial_types)
         self.wsgi = get_wsgi_server(app=self)

--- a/apistar/backends/sqlalchemy.py
+++ b/apistar/backends/sqlalchemy.py
@@ -3,6 +3,7 @@ from apistar.settings import Settings
 
 class SQLAlchemy(object):
     __slots__ = ('engine', 'session_class', 'metadata')
+    preload = True
 
     def __init__(self, engine, session_class, metadata=None):
         self.engine = engine

--- a/apistar/statics.py
+++ b/apistar/statics.py
@@ -13,7 +13,9 @@ PACKAGE_STATICS = os.path.join(PACKAGE_DIR, 'static')
 
 
 class Statics(object):
-    def __init__(self, root_dir):
+    preload = True
+
+    def __init__(self, root_dir=None):
         assert whitenoise is not None, 'whitenoise must be installed.'
         from whitenoise import WhiteNoise
         self.whitenoise = WhiteNoise(application=None, root=root_dir)

--- a/apistar/templating.py
+++ b/apistar/templating.py
@@ -9,6 +9,8 @@ from apistar.settings import Settings
 
 
 class Templates(jinja2.Environment):
+    preload = True
+
     @classmethod
     def build(cls, settings: Settings):
         template_dirs = settings.get(['TEMPLATES', 'DIRS'])


### PR DESCRIPTION
Closes #67.

This PR removes any requirement for the application __init__ to have hardcoded information about components that need to be preloaded.

We'll still want some kind of 'blueprints' or similar in order to have a nice shortcut for adding a bunch of commands etc.