### PR TITLE
Use twine for publishing distributions to PyPI

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,6 @@ werkzeug
 # Optional
 psycopg2
 sqlalchemy
-twine
 whitenoise
 
 # Testing requirements

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ werkzeug
 # Optional
 psycopg2
 sqlalchemy
+twine
 whitenoise
 
 # Testing requirements

--- a/scripts/publish
+++ b/scripts/publish
@@ -9,7 +9,8 @@ fi
 find apistar -type f -name "*.py[co]" -delete
 find apistar -type d -name __pycache__ -delete
 
-${PREFIX}python setup.py sdist upload
+${PREFIX}python setup.py sdist
+${PREFIX}twine upload dist/*
 
 rm -r dist
 

--- a/scripts/publish
+++ b/scripts/publish
@@ -10,10 +10,17 @@ find apistar -type f -name "*.py[co]" -delete
 find apistar -type d -name __pycache__ -delete
 
 ${PREFIX}python setup.py sdist
-${PREFIX}twine upload dist/*
+
+if command -v "twine" &>/dev/null; then
+    ${PREFIX}twine upload dist/*
+
+    echo "You probably want to also tag the version now:"
+    echo "git tag -a ${VERSION} -m 'version ${VERSION}'"
+    echo "git push --tags"
+else
+    echo "Unable to find the 'twine' command"
+    echo "Please install 'twine' from PyPI"
+    exit 1
+fi
 
 rm -r dist
-
-echo "You probably want to also tag the version now:"
-echo "git tag -a ${VERSION} -m 'version ${VERSION}'"
-echo "git push --tags"


### PR DESCRIPTION
Hi 👋 

I noticed that API Star uses ``python setup.py upload`` for publishing distributions to PyPI. This method is not recommended due to its security flaws, please see [PyPA guide](https://packaging.python.org/distributing/#uploading-your-project-to-pypi).

This PR replaces said method with ``twine upload dist/*``.

Please let me know your thoughts! 🙇 