### PR TITLE
Fixed Product schema in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,10 +216,12 @@ class ProductSize(schema.Enum):
 
 
 class Product(schema.Object):
-    name = schema.String(max_length=100),
-    rating = schema.Integer(minimum=1, maximum=5)
-    in_stock = schema.Boolean
-    size = ProductSize
+    properties = {
+        'name': schema.String(max_length=100),
+        'rating': schema.Integer(minimum=1, maximum=5),
+        'in_stock': schema.Boolean,
+        'size': ProductSize,
+    }
 ```
 
 ## Data Validation


### PR DESCRIPTION
I came to learn the documentation was incorrect and did not work for me. After digging in further I found out that `schema.Object` properties need to be in the `properties` dict and not defined on the class directly.