### PR TITLE
Fixed environment properties dictionary in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,7 +517,7 @@ from apistar import environment, schema
 
 class Env(environment.Environment):
     properties = {
-        'DEBUG': schema.Boolean(default=False)
+        'DEBUG': schema.Boolean(default=False),
         'DATABASE_URL': schema.String(default='sqlite://')
     }
 


### PR DESCRIPTION
I ran into the following error while going over the documentation,

'DATABASE_URL': schema.String(default='sqlite://')
                 ^
SyntaxError: invalid syntax