### PR TITLE
Django ORM Support

### DIFF
--- a/apistar/app.py
+++ b/apistar/app.py
@@ -36,7 +36,7 @@ class App(object):
             'app': self
         }
         preload_state(self.preloaded, self.routes)
-        if 'sql_alchemy' in self.preloaded:
+        if 'django_backend' in self.preloaded:
             self.commands += [cmd.create_tables]
 
         self.router = routing.Router(self.routes, initial_types)

--- a/apistar/backends/__init__.py
+++ b/apistar/backends/__init__.py
@@ -1,3 +1,4 @@
 from apistar.backends.sqlalchemy import SQLAlchemy
+from apistar.backends.django import DjangoBackend
 
-__all__ = ['SQLAlchemy']
+__all__ = ['SQLAlchemy', 'DjangoBackend']

--- a/apistar/backends/django.py
+++ b/apistar/backends/django.py
@@ -1,0 +1,30 @@
+from apistar.settings import Settings
+from django import setup
+from django.apps import apps
+from django.conf import settings as django_settings
+from django.core.management import call_command
+
+
+class DjangoBackend(object):
+
+    preload = True
+    _loaded = False
+
+    @classmethod
+    def build(cls, settings: Settings):
+        if not cls._loaded:
+            django_settings.configure(INSTALLED_APPS=settings.get('INSTALLED_APPS'),
+                                      DATABASES=settings.get('DATABASES'))
+            setup()
+            cls._loaded = True
+        dj = cls()
+        for model in apps.get_models():
+            setattr(dj, model.__name__, model)
+        return dj
+
+    def create_tables(self):
+        call_command('makemigrations')
+        call_command('migrate')
+
+    def drop_tables(self):
+        pass

--- a/apistar/commands/create_tables.py
+++ b/apistar/commands/create_tables.py
@@ -6,8 +6,8 @@ def create_tables():
     Create SQLAlchemy tables.
     """
     from apistar.main import get_current_app
-    from apistar.backends import SQLAlchemy
+    from apistar.backends import DjangoBackend
     app = get_current_app()
-    db_backend = SQLAlchemy.build(settings=app.settings)
+    db_backend = DjangoBackend.build(settings=app.settings)
     db_backend.create_tables()
     click.echo("Tables created")

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ requests
 werkzeug
 
 # Optional
+django
 psycopg2
 sqlalchemy
 whitenoise


### PR DESCRIPTION
Overview
---

This is a first draft of adding support for Django ORM. I have a working project example in a separate repo [here](https://github.com/linuxlewis/djangostar/tree/master/djangostar/example_project).

The idea for this component is that is returns an "models" object to which one accesses their models (after they've been loaded appropriately by django).

```python
def my_view(models: DjangoBackend):
     Star = models.Star
     s = Star(name="My Star")
     s.save()
     return {'name': star.name, 'id': star.id}
```

To configure the backend it expects 2 existing django settings: [DATABASES](https://docs.djangoproject.com/en/1.11/ref/settings/#databases) and [INSTALLED_APPS](https://docs.djangoproject.com/en/1.11/ref/settings/#installed-apps)
An example configuration can be found [here](https://github.com/linuxlewis/djangostar/blob/master/djangostar/example_project/app.py#L4-L15)

Any feedback or questions are welcomed.

Questions
---
- Can components have an API to register commands?
  - This seems to be the main blocker for this PR. I have a few ideas of how it could be done but I would defer to you if you have a implementation in mind.