### PR TITLE
Add support for schema.Array

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,16 @@ Validates dictionary or object input. A subclass of `dict`.
 
 Note that child properties are considered to be required if they do not have a `default` value.
 
+### Array
+
+Validates list or tuple input. A subclass of `list`.
+
+* `items` - A schema or type or a list of schemas or types.
+* `additional_items` - Whether additional items past the end of the listed schema types are permitted.
+* `min_items` - The minimum number of items the array must contain.
+* `max_items` - The maximum number of items the array must contain.
+* `unique_items` - Whether repeated items are permitted in the array.
+
 ## Generating API Schemas
 
 API Star is designed to be able to map well onto API description formats, known as "API Schemas".

--- a/apistar/routing.py
+++ b/apistar/routing.py
@@ -20,7 +20,7 @@ primitive_types = (
 
 schema_types = (
     schema.String, schema.Integer, schema.Number, schema.Boolean,
-    schema.Enum, schema.Object
+    schema.Enum, schema.Object, schema.Array
 )
 
 typing_types = (
@@ -127,7 +127,7 @@ class Router(object):
                     extra_annotations[param.name] = TypedURLPathArg
                 elif (annotated_type in primitive_types) or issubclass(annotated_type, schema_types):
                     if method in ('POST', 'PUT', 'PATCH'):
-                        if issubclass(annotated_type, schema.Object):
+                        if issubclass(annotated_type, (schema.Object, schema.Array)):
                             class TypedDataParam(http.RequestData):
                                 schema = annotated_type
                             extra_annotations[param.name] = TypedDataParam

--- a/tests/schema/test_array.py
+++ b/tests/schema/test_array.py
@@ -1,0 +1,91 @@
+import pytest
+
+from apistar import app, exceptions, routing, schema, test
+
+
+class UntypedList(schema.Array):
+    item_type = None
+
+
+class TypedList(schema.Array):
+    item_type = schema.Integer
+
+
+def basic_untyped_list(things: UntypedList):
+    return things
+
+
+def basic_typed_list(things: TypedList):
+    return things
+
+
+routes = [
+    routing.Route('/basic_typed_list/', 'POST', basic_typed_list),
+    routing.Route('/basic_untyped_list/', 'POST', basic_untyped_list),
+]
+
+app = app.App(routes=routes)
+client = test.TestClient(app)
+
+
+def test_valid_untyped_list():
+    payload = [
+        'foo',
+        'bar',
+        1,
+        3.1415927,
+        'baz',
+        True,
+        None,
+        'qux',
+        ['tribbles'] * 23,
+        {'foo': 'bar', 'baz': 'qux'},
+    ]
+
+    response = client.post('/basic_untyped_list/', json=payload)
+    assert response.status_code == 200
+    assert response.json() == payload
+
+
+def test_valid_typed_list():
+    payload = list(range(0, 10))
+
+    response = client.post('/basic_typed_list/', json=payload)
+    assert response.status_code == 200
+    assert response.json() == payload
+
+
+def test_invalid_typed_list():
+    payload = [1, 2, 'three', 4, '5ive']
+
+    response = client.post('/basic_typed_list/', json=payload)
+    assert response.status_code == 400
+    assert response.json() == {
+        '2': 'Must be a valid number.',
+        '4': 'Must be a valid number.',
+    }
+
+
+def test_array_instantiation():
+    typed = TypedList([0, 1, 2])
+    untyped = UntypedList([1, 'two', 3.3333, True, None])
+
+    for x in range(0, 3):
+        assert typed[x] == x
+
+    assert untyped[0] == 1
+    assert untyped[1] == 'two'
+    assert untyped[2] == 3.3333
+    assert untyped[3] is True
+    assert untyped[4] is None
+
+
+def test_array_invalid_type():
+    with pytest.raises(exceptions.SchemaError) as exc:
+        UntypedList(1)
+    assert str(exc.value) == 'Must be a list.'
+
+
+def test_array_kwargs():
+    NewTypedList = schema.Array(item_type=float)
+    assert NewTypedList([1.1, 2.2, 3.3]) == [1.1, 2.2, 3.3]

--- a/tests/schema/test_array.py
+++ b/tests/schema/test_array.py
@@ -4,11 +4,11 @@ from apistar import app, exceptions, routing, schema, test
 
 
 class UntypedList(schema.Array):
-    item_type = None
+    pass
 
 
 class TypedList(schema.Array):
-    item_type = schema.Integer
+    items = schema.Integer
 
 
 def basic_untyped_list(things: UntypedList):
@@ -87,5 +87,101 @@ def test_array_invalid_type():
 
 
 def test_array_kwargs():
-    NewTypedList = schema.Array(item_type=float)
+    NewTypedList = schema.Array(items=schema.Number)
     assert NewTypedList([1.1, 2.2, 3.3]) == [1.1, 2.2, 3.3]
+    with pytest.raises(exceptions.SchemaError) as exc:
+        NewTypedList([1, 2, 'c'])
+    assert 'Must be a valid number.' in str(exc.value)
+
+
+def test_array_specific_single_item():
+    SpecificTypeList = schema.Array(items=schema.Number)
+
+    assert SpecificTypeList([1, 2, 3, 4.5]) == [1, 2, 3, 4.5]
+    assert SpecificTypeList([]) == []
+
+    with pytest.raises(exceptions.SchemaError) as exc:
+        SpecificTypeList([1, 'two', 3])
+    assert 'Must be a valid number.' in str(exc.value)
+
+
+def test_array_specific_items_no_additional():
+    SpecificTypedList = schema.Array(items=[
+        schema.Number,
+        schema.String,
+        schema.Boolean
+    ], additional_items=False)
+
+    assert SpecificTypedList([23, 'twenty-three', True]) == \
+        [23, 'twenty-three', True]
+
+    with pytest.raises(exceptions.SchemaError) as exc:
+        SpecificTypedList([23, 'twenty-three'])
+    assert str(exc.value) == 'Not enough items.'
+
+    with pytest.raises(exceptions.SchemaError) as exc:
+        SpecificTypedList([23, 'twenty-three', True, False])
+    assert str(exc.value) == 'Too many items.'
+
+    with pytest.raises(exceptions.SchemaError) as exc:
+        SpecificTypedList(['.', 'twenty-three', True])
+    assert 'Must be a valid number.' in str(exc.value)
+
+
+def test_array_specific_items_with_additional():
+    SpecificTypedList = schema.Array(items=[
+        schema.Number,
+        schema.String,
+        schema.Boolean
+    ], additional_items=True)
+
+    assert SpecificTypedList([23, 'twenty-three', True]) == \
+        [23, 'twenty-three', True]
+
+    with pytest.raises(exceptions.SchemaError) as exc:
+        SpecificTypedList([23, 'twenty-three'])
+    assert str(exc.value) == 'Not enough items.'
+
+    assert SpecificTypedList([23, 'twenty-three', True, False]) == \
+        [23, 'twenty-three', True, False]
+
+
+def test_array_min_items():
+    MinimumItemList = schema.Array(min_items=2)
+
+    assert MinimumItemList([1, 2]) == [1, 2]
+    assert MinimumItemList([1, 2] * 10) == [1, 2] * 10
+
+    with pytest.raises(exceptions.SchemaError) as exc:
+        MinimumItemList([])
+    assert str(exc.value) == 'Not enough items.'
+
+    with pytest.raises(exceptions.SchemaError) as exc:
+        MinimumItemList([1])
+    assert str(exc.value) == 'Not enough items.'
+
+
+def test_array_max_items():
+    MaximumItemList = schema.Array(max_items=3)
+
+    assert MaximumItemList([1, 2]) == [1, 2]
+    assert MaximumItemList([]) == []
+
+    with pytest.raises(exceptions.SchemaError) as exc:
+        MaximumItemList([1, 2, 3, 4, 5])
+    assert str(exc.value) == 'Too many items.'
+
+    with pytest.raises(exceptions.SchemaError) as exc:
+        MaximumItemList([1] * 50)
+    assert str(exc.value) == 'Too many items.'
+
+
+def test_array_unique_items():
+    UniqueItemList = schema.Array(unique_items=True)
+
+    assert UniqueItemList([1, 2, 3, 4, 5]) == [1, 2, 3, 4, 5]
+    assert UniqueItemList([]) == []
+
+    with pytest.raises(exceptions.SchemaError) as exc:
+        UniqueItemList([1, 2, 3, 4, 1])
+    assert 'This item is not unique.' in str(exc.value)


### PR DESCRIPTION
This can either enforce a uniform item type or be completely open slather.

Addresses part of #70.