### PR TITLE
Fix flake8 warning in schema.py

### DIFF
--- a/apistar/schema.py
+++ b/apistar/schema.py
@@ -132,7 +132,7 @@ class _NumericType(object):
 
         if cls.multiple_of is not None:
             if isinstance(cls.multiple_of, float):
-                failed = not (value * (1/cls.multiple_of)).is_integer()
+                failed = not (value * (1 / cls.multiple_of)).is_integer()
             else:
                 failed = value % cls.multiple_of
             if failed:


### PR DESCRIPTION
This fixes the lonely flake8 error.

Before:
```
$ ./scripts/lint
+ venv/bin/flake8 apistar tests
apistar/schema.py:135:41: E226 missing whitespace around arithmetic operator
```

After:
```
$ ./scripts/lint
+ venv/bin/flake8 apistar tests
+ venv/bin/isort apistar tests --recursive --check-only
+ venv/bin/mypy apistar tests --ignore-missing-imports
```