### PR TITLE
Unquote urlpath in apistar.TestClient

### DIFF
--- a/apistar/test.py
+++ b/apistar/test.py
@@ -1,5 +1,5 @@
 import io
-from urllib.parse import urlparse
+from urllib.parse import unquote, urlparse
 
 import requests
 from click.testing import CliRunner
@@ -30,7 +30,7 @@ class WSGIAdapter(requests.adapters.HTTPAdapter):
             'REQUEST_METHOD': request.method,
             'wsgi.url_scheme': url_components.scheme,
             'SCRIPT_NAME': self.root_path,
-            'PATH_INFO': url_components.path,
+            'PATH_INFO': unquote(url_components.path),
             'wsgi.input': io.BytesIO(body),
             'APISTAR_RAISE_500_EXC': self.raise_500_exc
         }

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -57,6 +57,12 @@ def path_param_with_integer(var: schema.Integer):
     }
 
 
+def path_param_with_string(var: schema.String):
+    return {
+        'var': var
+    }
+
+
 def subpath(var: schema.Integer):
     return {
         'var': var
@@ -72,6 +78,7 @@ app = App(routes=[
     Route('/max_length/{var}/', 'GET', path_param_with_max_length),
     Route('/number/{var}/', 'GET', path_param_with_number),
     Route('/integer/{var}/', 'GET', path_param_with_integer),
+    Route('/string/{var}/', 'GET', path_param_with_string),
     Include('/subpath', [
         Route('/{var}/', 'GET', subpath),
     ]),
@@ -195,6 +202,14 @@ def test_invalid_integer():
     assert response.status_code == 404
     assert response.json() == {
         'message': 'Not found'
+    }
+
+
+def test_valid_string():
+    response = client.get('/string/hello world/')
+    assert response.status_code == 200
+    assert response.json() == {
+        'var': 'hello world'  # makes sure we don't return hello%20world
     }
 
 


### PR DESCRIPTION
This resolves issue #158 where `client.get("/December 15, 2015")`
url was coming up as `December%2015,%202015` in the view function.