### PR TITLE
Support for URL Reversing in Router

### DIFF
--- a/apistar/exceptions.py
+++ b/apistar/exceptions.py
@@ -57,5 +57,8 @@ class UnsupportedMediaType(APIException):
 
 
 class NoReverseMatch(APIException):
+    """Exception for when no route was found when reversing a view to a URL.
+    Triggered by routing.Router.reverse_url() on a method not mapped to a view or route.
+    """
     default_status_code = 500
     default_detail = 'No reverse match found for view'

--- a/apistar/exceptions.py
+++ b/apistar/exceptions.py
@@ -54,3 +54,8 @@ class MethodNotAllowed(APIException):
 class UnsupportedMediaType(APIException):
     default_status_code = 415
     default_detail = 'Unsupported media type in request'
+
+
+class NoReverseMatch(APIException):
+    default_status_code = 500
+    default_detail = 'No reverse match found for view'

--- a/apistar/routing.py
+++ b/apistar/routing.py
@@ -180,9 +180,6 @@ class Router(object):
             if route.view == endpoint.view
         ]
 
-        if not matched_views:
-            raise ValueError('No view "{}" found.'.format(view_name))
-
         return matched_views[0].path.format(**url_params)
 
 

--- a/apistar/routing.py
+++ b/apistar/routing.py
@@ -172,7 +172,7 @@ class Router(object):
     def reverse_url(self, view_name: str, **url_params) -> str:
         endpoint = self.views.get(view_name)
         if not endpoint:
-            raise ValueError('No view "{}" found.'.format(view_name))
+            raise exceptions.NoReverseMatch
 
         flattened_routes = walk(self.routes)
         matched_views = [

--- a/apistar/routing.py
+++ b/apistar/routing.py
@@ -174,16 +174,16 @@ class Router(object):
         if not endpoint:
             raise ValueError('No view "{}" found.'.format(view_name))
 
-        matched_view = [
-            view for view in self.routes
-            if isinstance(view, Route) and view.view == endpoint.view
+        flattened_routes = walk(self.routes)
+        matched_views = [
+            route for route in flattened_routes
+            if route.view == endpoint.view
         ]
 
-        if not matched_view:
+        if not matched_views:
             raise ValueError('No view "{}" found.'.format(view_name))
 
-        path = matched_view[0].path.format(**url_params)
-        return path
+        return matched_views[0].path.format(**url_params)
 
 
 def exception_handler(environ: wsgi.WSGIEnviron,

--- a/apistar/routing.py
+++ b/apistar/routing.py
@@ -169,6 +169,22 @@ class Router(object):
         (view, pipeline) = self.views[name]
         return (view, pipeline, kwargs)
 
+    def reverse_url(self, view_name: str, **url_params) -> str:
+        endpoint = self.views.get(view_name)
+        if not endpoint:
+            raise ValueError('No view "{}" found.'.format(view_name))
+
+        matched_view = [
+            view for view in self.routes
+            if isinstance(view, Route) and view.view == endpoint.view
+        ]
+
+        if not matched_view:
+            raise ValueError('No view "{}" found.'.format(view_name))
+
+        path = matched_view[0].path.format(**url_params)
+        return path
+
 
 def exception_handler(environ: wsgi.WSGIEnviron,
                       exc: Exception) -> http.Response:

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -226,21 +226,21 @@ def test_lookup_cache_expiry():
         assert response.json() == {'path': '/%d/' % index}
 
 
-@pytest.mark.skip('WIP')
 def test_routing_reversal_on_path_without_url_params():
-    pass
+    url = app.router.reverse_url('found')
+    assert url == 'http://localhost:8080/found/'
 
 
-@pytest.mark.skip('WIP')
 def test_routing_reversal_on_path_non_existent_path():
-    pass
+    with pytest.raises(exceptions.NotFound):
+        app.router.reverse_url('missing', var='not_here')
 
 
-@pytest.mark.skip('WIP')
 def test_routing_reversal_on_path_with_url_params():
-    pass
+    url = app.router.reverse_url('path_params', var='test')
+    assert url == 'http://localhost:8080/path_params/test/'
 
 
-@pytest.mark.skip('WIP')
 def test_routing_reversal_on_subpath_with_url_params():
-    pass
+    url = app.router.reverse_url('subpath', var='testing')
+    assert url == 'http://localhost:8080/subpath/testing/'

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -232,7 +232,7 @@ def test_routing_reversal_on_path_without_url_params():
 
 
 def test_routing_reversal_on_path_non_existent_path():
-    with pytest.raises(ValueError):
+    with pytest.raises(exceptions.NoReverseMatch):
         app.router.reverse_url('missing', var='not_here')
 
 

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -228,19 +228,19 @@ def test_lookup_cache_expiry():
 
 def test_routing_reversal_on_path_without_url_params():
     url = app.router.reverse_url('found')
-    assert url == 'http://localhost:8080/found/'
+    assert url == '/found/'
 
 
 def test_routing_reversal_on_path_non_existent_path():
-    with pytest.raises(exceptions.NotFound):
+    with pytest.raises(ValueError):
         app.router.reverse_url('missing', var='not_here')
 
 
 def test_routing_reversal_on_path_with_url_params():
     url = app.router.reverse_url('path_params', var='test')
-    assert url == 'http://localhost:8080/path_params/test/'
+    assert url == '/path_params/test/'
 
 
 def test_routing_reversal_on_subpath_with_url_params():
     url = app.router.reverse_url('subpath', var='testing')
-    assert url == 'http://localhost:8080/subpath/testing/'
+    assert url == '/subpath/testing/'

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -224,3 +224,23 @@ def test_lookup_cache_expiry():
         response = client.get('/%d/' % index)
         assert response.status_code == 200
         assert response.json() == {'path': '/%d/' % index}
+
+
+@pytest.mark.skip('WIP')
+def test_routing_reversal_on_path_without_url_params():
+    pass
+
+
+@pytest.mark.skip('WIP')
+def test_routing_reversal_on_path_non_existent_path():
+    pass
+
+
+@pytest.mark.skip('WIP')
+def test_routing_reversal_on_path_with_url_params():
+    pass
+
+
+@pytest.mark.skip('WIP')
+def test_routing_reversal_on_subpath_with_url_params():
+    pass


### PR DESCRIPTION
Add support for [Flask-like `url_for()` URL building](http://flask.pocoo.org/docs/0.12/api/#flask.url_for) in API Star:

# Details
- Returns a relative URL.
- Part of work for issue #77 
