### PR TITLE
Update the README to use the Rating class within Schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ class ProductSize(schema.Enum):
 class Product(schema.Object):
     properties = {
         'name': schema.String(max_length=100),
-        'rating': schema.Integer(minimum=1, maximum=5),
+        'rating': Rating,
         'in_stock': schema.Boolean,
         'size': ProductSize,
     }


### PR DESCRIPTION
In the Schemas section of the README, a class called Rating is defined, but is not used within the Product class (which instead defines another identical rating with integers). This change is just to use that class rather than redefining it.