### PR TITLE
Removes static server name since it's no longer required.

### DIFF
--- a/apistar/routing.py
+++ b/apistar/routing.py
@@ -152,7 +152,7 @@ class Router(object):
 
         self.exception_pipeline = pipelines.build_pipeline(exception_handler, initial_types, required_type, {})
         self.routes = routes
-        self.adapter = Map(rules).bind('example.com')
+        self.adapter = Map(rules).bind('')
         self.views = views
 
     def lookup(self, path: str, method: str) -> RouterLookup:


### PR DESCRIPTION
Redirects are still functional without this hardcoded `example.com`. 

[RFC 7231 &#8594;](https://tools.ietf.org/html/rfc7231#section-7.1.2)
[Werkzueg Router Docs &#8594;](http://werkzeug.pocoo.org/docs/0.12/routing/#werkzeug.routing.Map.bind)