### PR TITLE
Allow forward references (str-type) in annotations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .cache
 .coverage
 .git
+.mypy_cache
 __pycache__
 /*.egg-info
 /htmlcov

--- a/apistar/apischema.py
+++ b/apistar/apischema.py
@@ -15,6 +15,7 @@ from apistar.routing import (
     Route, RoutesConfig, primitive_types, schema_types, walk
 )
 from apistar.templating import Templates
+from apistar.util import resolve_class
 
 
 class APISchema(Document):
@@ -68,7 +69,7 @@ def get_link(route: Route) -> Link:
         if param.annotation is inspect.Signature.empty:
             annotated_type = str
         else:
-            annotated_type = param.annotation
+            annotated_type = resolve_class(param.annotation)
 
         location = None
         required = False

--- a/apistar/pipelines.py
+++ b/apistar/pipelines.py
@@ -3,6 +3,8 @@ import re
 from collections import namedtuple
 from typing import Any, Callable, Dict, List  # noqa
 
+from apistar.util import resolve_class
+
 empty = inspect.Signature.empty
 FIRST_CAP_RE = re.compile('(.)([A-Z][a-z]+)')
 ALL_CAP_RE = re.compile('([a-z0-9])([A-Z])')
@@ -81,6 +83,8 @@ def _build_step(function: Callable,
         else:
             parameter_cls = parameter.annotation
 
+        parameter_cls = resolve_class(parameter_cls)
+
         if parameter_cls == ArgName:
             extra_kwargs[parameter.name] = arg_name
         else:
@@ -88,7 +92,7 @@ def _build_step(function: Callable,
             inputs.append(input)
 
     if 'return' in extra_annotations:
-        return_cls = extra_annotations['return']
+        return_cls = resolve_class(extra_annotations['return'])
     else:
         return_cls = signature.return_annotation
         if return_cls is empty:
@@ -114,7 +118,7 @@ def _build_pipeline(function: Callable,
     signature = inspect.signature(function)
     for parameter in signature.parameters.values():
         annotation = extra_annotations.get(parameter.name, parameter.annotation)
-
+        annotation = resolve_class(annotation)
         if get_class_id(annotation, parameter.name) in seen:
             # Don't build a dependancy if it has already been satisfied.
             continue

--- a/apistar/routing.py
+++ b/apistar/routing.py
@@ -13,6 +13,7 @@ from werkzeug.serving import is_running_from_reloader
 
 from apistar import exceptions, http, pipelines, schema, wsgi
 from apistar.pipelines import ArgName, Pipeline
+from apistar.util import resolve_class
 
 primitive_types = (
     str, int, float, bool, list, dict
@@ -119,7 +120,7 @@ class Router(object):
                 if param.annotation is inspect.Signature.empty:
                     annotated_type = str
                 else:
-                    annotated_type = param.annotation
+                    annotated_type = resolve_class(param.annotation)
 
                 if param.name in uritemplate.variable_names:
                     class TypedURLPathArg(URLPathArg):

--- a/apistar/util.py
+++ b/apistar/util.py
@@ -1,0 +1,15 @@
+import importlib
+
+
+def resolve_class(cls_or_str):
+    """
+    Dynamically resolve string type annotations.
+    This allows "forward references" to help break circular references.
+    """
+    if not isinstance(cls_or_str, str):
+        return cls_or_str
+
+    path = cls_or_str.split('.')
+    package = '.'.join(path[:-1])
+    module = path[-1]
+    return getattr(importlib.import_module(package), module)

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -1,3 +1,4 @@
+import apistar  # noqa
 from apistar import App, Route, http
 from apistar.test import TestClient
 
@@ -292,6 +293,10 @@ def empty_response():
     return b''
 
 
+def settings_forward_reference_response(settings: 'apistar.settings.Settings'):
+    return settings
+
+
 def unknown_status_code() -> http.Response:
     data = {'hello': 'world'}
     return http.Response(data, status=600)
@@ -346,6 +351,18 @@ def test_empty_response():
     assert response.status_code == 204
     assert response.text == ''
     assert 'Content-Type' not in response.headers
+
+
+def test_settings_forward_reference_response():
+    app = App(
+        routes=[Route('/', 'GET', settings_forward_reference_response)],
+        settings={
+            'foo': 'bar'
+        }
+    )
+    client = TestClient(app)
+    response = client.get('/')
+    assert response.json() == {'foo': 'bar'}
 
 
 def test_unknown_status_code():


### PR DESCRIPTION
Allows strings as type annotations in order to break circular references.

This works fine with mypy static type checking as long as the module is included. For instance:

```py
from typing import TYPE_CHECKING

if TYPE_CHECKING:
    # if imported at runtime, this will cause a circular import,
    # but mypy needs it in this module in order to resolve it
    import apistar.settings

class A:
    @classmethod
    def build(cls, settings: 'apistar.settings.Settings'):
        # ...
```