### PR TITLE
Add include example to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,21 @@ app = App(routes=[
 ])
 ```
 
+Use `Include` to include a list of routes.
+
+```python
+star_routes=[
+    Route('/', 'GET', list_stars),
+    Route('/', 'POST', create_new_star),
+    Route('/{star_id}', 'PUT', edit_star),
+    Route('/{star_id}', 'DELETE', delete_star)
+]
+
+app = App(routes=[
+    Include('/api/star', star_routes)
+])
+```
+
 Use type annotation on the view method to include typed URL path parameters.
 
 ```python


### PR DESCRIPTION
I feel like `Include` are really useful and we need an example for them in the README file (even just to inform)