### PR TITLE
Add compat entry for urllib3 due to new requests version

### DIFF
--- a/apistar/compat.py
+++ b/apistar/compat.py
@@ -10,3 +10,12 @@ try:
     import whitenoise
 except ImportError:  # pragma: no cover
     whitenoise = None
+
+
+# requests >=2.16.0 no longer includes vendored packages and lists urllib3 as a dependency
+try:
+    import urllib3
+except ImportError:  # pragma: no cover
+    # requests installation is <2.16.0
+    import requests
+    urllib3 = requests.packages.urllib3

--- a/apistar/test.py
+++ b/apistar/test.py
@@ -6,6 +6,7 @@ import requests
 from click.testing import CliRunner
 
 from apistar.cli import get_current_app
+from apistar.compat import urllib3
 
 
 class WSGIAdapter(requests.adapters.HTTPAdapter):
@@ -77,7 +78,7 @@ class WSGIAdapter(requests.adapters.HTTPAdapter):
 
         # Build the underlying urllib3.HTTPResponse
         raw_kwargs['body'] = io.BytesIO(b''.join(wsgi_response))
-        raw = requests.packages.urllib3.HTTPResponse(**raw_kwargs)
+        raw = urllib3.HTTPResponse(**raw_kwargs)
 
         # Build the requests.Response
         return self.build_response(request, raw)


### PR DESCRIPTION
Requests 2.16.0 removes vendored packages, this compat entry allows for older and newer versions of requests. Can be removed once we pin requests at `2.16.0`

Fixes errors in #188 PR and is pretty much the same fix used in my [rest framework PR](https://github.com/encode/django-rest-framework/pull/5185)