### PR TITLE
Adds support for callable default values in Schema definitions

### DIFF
--- a/apistar/schema.py
+++ b/apistar/schema.py
@@ -240,7 +240,10 @@ class Object(dict):
             except KeyError:
                 if hasattr(child_schema, 'default'):
                     # If a key is missing but has a default, then use that.
-                    self[key] = child_schema.default
+                    if callable(child_schema.default):
+                        self[key] = child_schema.default()
+                    else:
+                        self[key] = child_schema.default
                 else:
                     errors[key] = error_message(self, 'required')
             else:

--- a/tests/schema/test_object.py
+++ b/tests/schema/test_object.py
@@ -20,6 +20,17 @@ class HighScore(schema.Object):
     }
 
 
+def get_artist_id():
+    return 1
+
+
+class Artist(schema.Object):
+    properties = {
+        'id': schema.Integer(default=get_artist_id),
+        'name': schema.String(max_length=100)
+    }
+
+
 def basic_object(score: HighScore):
     return score
 
@@ -117,3 +128,8 @@ class test_object_invalid_type():
     with pytest.raises(exceptions.SchemaError) as exc:
         HighScore(1)
     assert str(exc.value) == 'Must be an object.'
+
+
+class test_object_with_callable_default():
+    artist = Artist({"name": "John Doe"})
+    assert artist['id'] == 1


### PR DESCRIPTION
I think sometimes is very handy to be able to use functions as default values when you are defining a schema:

    def generate_uuid():
        return str(uuid.uuid4())

    class Artist(schema.Object):
        properties = {
            'id': schema.String(max_length=100, default=generate_uuid),
            'name': schema.String(max_length=100),
        }

This way I can use the schema as a template for creating new objects. I don't know if this is beyond the scope of the schemas but It would be nice to have this feature.

Thanks in advance!