### PR TITLE
Fix for Python defaulting to using stdlib typing

### DIFF
--- a/apistar/apischema.py
+++ b/apistar/apischema.py
@@ -1,6 +1,8 @@
 import base64
 import inspect
-from typing import Dict, Optional, Type, cast
+from typing import Dict, Optional, cast
+if False:
+    from typing import Type
 from urllib.parse import urljoin
 
 import coreschema


### PR DESCRIPTION
Fixes issue #122.

Solution taken from #306