### PR TITLE
Turn off Werkzeug debugger with `run --no-debugger`

### DIFF
--- a/README.md
+++ b/README.md
@@ -935,6 +935,12 @@ both performance and for productivity.
 A development server is available, using the `run` command:
 
     $ apistar run
+    # Specify the port or interface via --port and --host
+    # Serve on port 9001 and use IPv6 only
+    $ apistar run --port 9001 --host ::1
+    # If you don't like the Werkzeug web debugger, turn it off
+    $ apistar run --no-debugger
+
 
 ## Running in Production
 

--- a/apistar/commands/run.py
+++ b/apistar/commands/run.py
@@ -14,7 +14,12 @@ class Port(schema.Integer):
     default = 8080
 
 
-def run(host: Host, port: Port) -> None:  # pragma: nocover
+class NoDebugger(schema.Boolean):
+    description = 'Turn off the Werkzeug debugger (on by default)'
+    default = False
+
+
+def run(host: Host, port: Port, no_debugger: NoDebugger) -> None:  # pragma: nocover
     """
     Run the current app.
     """
@@ -24,6 +29,6 @@ def run(host: Host, port: Port) -> None:  # pragma: nocover
     try:
         if not is_running_from_reloader():
             click.echo('Starting up...')
-        run_simple(host, port, app.wsgi, use_reloader=True, use_debugger=True, extra_files=['app.py'])
+        run_simple(host, port, app.wsgi, use_reloader=True, use_debugger=(not no_debugger), extra_files=['app.py'])
     except KeyboardInterrupt:
         pass


### PR DESCRIPTION
Some debugging workflows (like embedding epdb/pdb/etc) get tripped up
by the hooks the Werkzeug debugger uses to present the web UI debugger.
This PR adds a `--no-debugger` option to turn off Werkzeug but leave on the
auto-reload features.

To test this out, run any API* project with `apistar run --no-debugger` and do something that triggers an exception. The traceback will be logged, and a 500 response will be sent back, but the web debugger won't start. 