### PR TITLE
Add link descriptions in schema

### DIFF
--- a/apistar/apischema.py
+++ b/apistar/apischema.py
@@ -1,6 +1,7 @@
 import base64
 import inspect
-from typing import Dict, Optional, Type, cast
+import textwrap
+from typing import Callable, Dict, Optional, Type, cast
 from urllib.parse import urljoin
 
 import coreschema
@@ -66,6 +67,12 @@ def _annotated_type_to_coreschema(annotated_type: type) -> coreschema.schemas.Sc
     return coreschema.String()
 
 
+def _get_link_description(view: Callable) -> Optional[str]:
+    if view.__doc__:
+        return textwrap.dedent(view.__doc__).strip()
+    return None
+
+
 def get_link(route: Route) -> Link:
     """
     Given a single route, return a Link instance containing all the information
@@ -75,6 +82,8 @@ def get_link(route: Route) -> Link:
 
     view_signature = inspect.signature(view)
     uritemplate = URITemplate(path)
+
+    description = _get_link_description(view)
 
     fields = []
     for param in view_signature.parameters.values():
@@ -104,7 +113,7 @@ def get_link(route: Route) -> Link:
             field = Field(name=param.name, location=location, required=required, schema=param_schema)
             fields.append(field)
 
-    return Link(url=path, action=method, fields=fields)
+    return Link(url=path, action=method, description=description, fields=fields)
 
 
 @exclude_from_schema

--- a/tests/test_apischema.py
+++ b/tests/test_apischema.py
@@ -25,10 +25,17 @@ class ToDoNote(schema.Object):
 
 
 def list_todo(app: App, search):  # pragma: nocover
+    """
+    list_todo description
+    """
     pass
 
 
 def add_todo(note: ToDoNote):  # pragma: nocover
+    """
+    add_todo description
+    Multiple indented lines
+    """
     pass
 
 
@@ -68,11 +75,13 @@ expected = APISchema(url='/schema/', content={
     'list_todo': Link(
         url='/todo/',
         action='GET',
+        description='list_todo description',
         fields=[Field(name='search', location='query', required=False, schema=coreschema.String())]
     ),
     'add_todo': Link(
         url='/todo/',
         action='POST',
+        description='add_todo description\nMultiple indented lines',
         fields=[Field(name='note', location='body', required=True, schema=coreschema.String())]
     ),
     'show_todo': Link(


### PR DESCRIPTION
Related to #69.

Hi there,

I'll try to bring my modest contribution to this project. This is a simple proposal to bring Link descriptions to the API schema, simply by providing a docstring in the view function.

Not sure if it's the way you imagined for this ; I took inspiration from how it works in DRF. If not, no problem, I would be happy to work on this ; and also on Field descriptions.

Best regards!